### PR TITLE
Rework scroll-to-end algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Playground: bumped to `react@16.6.0`, `react-dom@16.6.0`, and `react-scripts@2.1.6`
+- Update algorithm, instead of using `componentDidUpdate`, we now use `setInterval` to check if the panel is sticky or not, this help to track content update that happen outside of React lifecycle, for example, `HTMLImageElement.onload` event
+
+### Removed
+- Removed `threshold` props because the algorithm is now more robust
 
 ## [1.2.0] - 2018-10-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Playground: bumped to `react@16.6.0`, `react-dom@16.6.0`, and `react-scripts@2.1.6`
 - Update algorithm, instead of using `componentDidUpdate`, we now use `setInterval` to check if the panel is sticky or not, this help to track content update that happen outside of React lifecycle, for example, `HTMLImageElement.onload` event
+- `scrollTo()` now accepts `"100%"` instead of `"bottom"`
 
 ### Removed
 - Removed `threshold` props because the algorithm is now more robust

--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ This context contains functions used to manipulate the container. And will not u
 
 This context contains state of the container.
 
-| Name        | Type      | Description                                                         |
-|-------------|-----------|---------------------------------------------------------------------|
-| `animating` | `boolean` | `true` if the panel is animating scroll effect                      |
-| `atBottom`  | `boolean` | `true` if the panel is currently near bottom                        |
-| `atEnd`     | `boolean` | `true` if the panel is currently near the end (depends on `mode`)   |
-| `atStart`   | `boolean` | `true` if the panel is currently near the start (depends on `mode`) |
-| `atTop`     | `boolean` | `true` if the panel is currently near top                           |
-| `mode`      | `string`  | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top          |
+| Name            | Type      | Default    | Description                                                         |
+|-----------------|-----------|------------|---------------------------------------------------------------------|
+| `animating`     | `boolean` | `false`    | `true` if the panel is animating scroll effect                      |
+| `atBottom`      | `boolean` |            | `true` if the panel is currently near bottom                        |
+| `atEnd`         | `boolean` |            | `true` if the panel is currently near the end (depends on `mode`)   |
+| `atStart`       | `boolean` |            | `true` if the panel is currently near the start (depends on `mode`) |
+| `atTop`         | `boolean` |            | `true` if the panel is currently near top                           |
+| `checkInterval` | `number`  | 150        | Recurring interval of stickiness check, in milliseconds             |
+| `debounce`      | `number`  | 17         | Debounce interval for `scroll` event, in milliseconds               |
+| `mode`          | `string`  | `"bottom"` | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top          |
 
 # Road map
 

--- a/README.md
+++ b/README.md
@@ -49,27 +49,26 @@ We use 2 different contexts with different performance characteristics to provid
 
 This context contains functions used to manipulate the container. And will not update throughout the lifetime of the composer.
 
-| Name | Type | Description |
-| - | - | - |
-| `scrollTo` | `(scrollTop: number | 'bottom') => void` | Scroll panel to specified position |
-| `scrollToBottom` | `() => void` | Scroll panel to bottom |
-| `scrollToEnd` | `() => void` | Scroll panel to end (depends on `mode`) |
-| `scrollToStart` | `() => void` | Scroll panel to start (depends on `mode`) |
-| `scrollToTop` | `() => void` | Scroll panel to top |
+| Name             | Type                                     | Description                               |
+|------------------|------------------------------------------|-------------------------------------------|
+| `scrollTo`       | `(scrollTop: number | 'bottom') => void` | Scroll panel to specified position        |
+| `scrollToBottom` | `() => void`                             | Scroll panel to bottom                    |
+| `scrollToEnd`    | `() => void`                             | Scroll panel to end (depends on `mode`)   |
+| `scrollToStart`  | `() => void`                             | Scroll panel to start (depends on `mode`) |
+| `scrollToTop`    | `() => void`                             | Scroll panel to top                       |
 
 ### State context
 
 This context contains state of the container.
 
-| Name | Type | Description |
-| - | - | - |
-| `animating` | `boolean` | `true` if the panel is animating scroll effect |
-| `atBottom` | `boolean` | `true` if the panel is currently near bottom (see `threshold`) |
-| `atEnd` | `boolean` | `true` if the panel is currently near the end (depends on `mode`, see `mode` and `threshold` |
-| `atStart` | `boolean` | `true` if the panel is currently near the start (depends on `mode`, see `threshold`) |
-| `atTop` | `boolean` | `true` if the panel is currently near top (see `threshold`) |
-| `mode` | `string` | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top |
-| `threshold` | `number` | Threshold in pixels to consider the panel is near top/bottom, read-only and only set thru `props` |
+| Name        | Type      | Description                                                         |
+|-------------|-----------|---------------------------------------------------------------------|
+| `animating` | `boolean` | `true` if the panel is animating scroll effect                      |
+| `atBottom`  | `boolean` | `true` if the panel is currently near bottom                        |
+| `atEnd`     | `boolean` | `true` if the panel is currently near the end (depends on `mode`)   |
+| `atStart`   | `boolean` | `true` if the panel is currently near the start (depends on `mode`) |
+| `atTop`     | `boolean` | `true` if the panel is currently near top                           |
+| `mode`      | `string`  | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top          |
 
 # Road map
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export default props =>
 
 | Name                    | Type     | Default    | Description                                                                  |
 |-------------------------|----------|------------|------------------------------------------------------------------------------|
-| `checkInterval`         | `number` | 150        | Recurring interval of stickiness check, in milliseconds                      |
+| `checkInterval`         | `number` | 150        | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)   |
 | `className`             | `string` |            | Set the class name for the root element                                      |
 | `debounce`              | `number` | `17`       | Set the debounce for tracking the `onScroll` event                           |
 | `followButtonClassName` | `string` |            | Set the class name for the follow button                                     |

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ export default props =>
 
 ## Props
 
-| Name | Default | Description |
-| - | - | - |
-| `className` | | Set the class name for the root element |
-| `debounce` | `17` | Set the debounce for tracking the `onScroll` event |
-| `followButtonClassName` | | Set the class name for the follow button |
-| `mode` | `"bottom"` | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top |
-| `scrollViewClassName` | | Set the class name for the container element that house all `props.children` |
+| Name                    | Type     | Default    | Description                                                                  |
+|-------------------------|----------|------------|------------------------------------------------------------------------------|
+| `checkInterval`         | `number` | 150        | Recurring interval of stickiness check, in milliseconds                      |
+| `className`             | `string` |            | Set the class name for the root element                                      |
+| `debounce`              | `number` | `17`       | Set the debounce for tracking the `onScroll` event                           |
+| `followButtonClassName` | `string` |            | Set the class name for the follow button                                     |
+| `mode`                  | `string` | `"bottom"` | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top         |
+| `scrollViewClassName`   | `string` |            | Set the class name for the container element that house all `props.children` |
 
 ## Context
 
@@ -49,28 +50,29 @@ We use 2 different contexts with different performance characteristics to provid
 
 This context contains functions used to manipulate the container. And will not update throughout the lifetime of the composer.
 
-| Name             | Type                                     | Description                               |
-|------------------|------------------------------------------|-------------------------------------------|
-| `scrollTo`       | `(scrollTop: number | 'bottom') => void` | Scroll panel to specified position        |
-| `scrollToBottom` | `() => void`                             | Scroll panel to bottom                    |
-| `scrollToEnd`    | `() => void`                             | Scroll panel to end (depends on `mode`)   |
-| `scrollToStart`  | `() => void`                             | Scroll panel to start (depends on `mode`) |
-| `scrollToTop`    | `() => void`                             | Scroll panel to top                       |
+| Name             | Type                                   | Description                               |
+|------------------|----------------------------------------|-------------------------------------------|
+| `scrollTo`       | `(scrollTop: number | '100%') => void` | Scroll panel to specified position        |
+| `scrollToBottom` | `() => void`                           | Scroll panel to bottom                    |
+| `scrollToEnd`    | `() => void`                           | Scroll panel to end (depends on `mode`)   |
+| `scrollToStart`  | `() => void`                           | Scroll panel to start (depends on `mode`) |
+| `scrollToTop`    | `() => void`                           | Scroll panel to top                       |
 
 ### State context
 
 This context contains state of the container.
 
-| Name            | Type      | Default    | Description                                                         |
-|-----------------|-----------|------------|---------------------------------------------------------------------|
-| `animating`     | `boolean` | `false`    | `true` if the panel is animating scroll effect                      |
-| `atBottom`      | `boolean` |            | `true` if the panel is currently near bottom                        |
-| `atEnd`         | `boolean` |            | `true` if the panel is currently near the end (depends on `mode`)   |
-| `atStart`       | `boolean` |            | `true` if the panel is currently near the start (depends on `mode`) |
-| `atTop`         | `boolean` |            | `true` if the panel is currently near top                           |
-| `checkInterval` | `number`  | 150        | Recurring interval of stickiness check, in milliseconds             |
-| `debounce`      | `number`  | 17         | Debounce interval for `scroll` event, in milliseconds               |
-| `mode`          | `string`  | `"bottom"` | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top          |
+| Name        | Type      | Description                                                         |
+|-------------|-----------|---------------------------------------------------------------------|
+| `animating` | `boolean` | `true` if the panel is animating scroll effect                      |
+| `atBottom`  | `boolean` | `true` if the panel is currently near bottom                        |
+| `atEnd`     | `boolean` | `true` if the panel is currently near the end (depends on `mode`)   |
+| `atStart`   | `boolean` | `true` if the panel is currently near the start (depends on `mode`) |
+| `atTop`     | `boolean` | `true` if the panel is currently near top                           |
+| `mode`      | `string`  | `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top          |
+| `sticky`    | `boolean` | `true` if the panel is sticking to the end                          |
+
+> `atEnd` and `sticky` are slightly different. During scroll animation, the panel is not at the end yet, but it is still sticky.
 
 # Road map
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
-    "test": "lerna run test --stream"
+    "test": "lerna run test --stream",
+    "watch": "lerna run watch --parallel --stream"
   },
   "devDependencies": {
     "lerna": "^3.4.3"

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "build": "babel --out-dir lib --ignore **/*.spec.js,**/*.test.js --source-maps inline --verbose src/",
     "clean": "rimraf lib",
-    "test": "echo no test specified"
+    "test": "echo no test specified",
+    "watch": "npm run build -- --watch"
   },
   "author": "William Wong <compulim@hotmail.com> (http://compulim.info/)",
   "license": "MIT",

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -10,15 +10,24 @@ const ROOT_CSS = css({
   position: 'relative'
 });
 
-export default props =>
+export default ({
+  checkInterval,
+  children,
+  className,
+  debounce,
+  followButtonClassName,
+  mode,
+  scrollViewClassName
+}) =>
   <Composer
-    debounce={ props.debounce }
-    mode={ props.mode === 'top' ? 'top' : 'bottom'}
+    checkInterval={ checkInterval }
+    debounce={ debounce }
+    mode={ mode === 'top' ? 'top' : 'bottom'}
   >
-    <div className={ classNames(ROOT_CSS + '', (props.className || '') + '') }>
-      <Panel className={ props.scrollViewClassName }>
-        { props.children }
+    <div className={ classNames(ROOT_CSS + '', (className || '') + '') }>
+      <Panel className={ scrollViewClassName }>
+        { children }
       </Panel>
-      <AutoHideFollowButton className={ props.followButtonClassName } />
+      <AutoHideFollowButton className={ followButtonClassName } />
     </div>
   </Composer>

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -14,7 +14,6 @@ export default props =>
   <Composer
     debounce={ props.debounce }
     mode={ props.mode === 'top' ? 'top' : 'bottom'}
-    threshold={ props.threshold }
   >
     <div className={ classNames(ROOT_CSS + '', (props.className || '') + '') }>
       <Panel className={ props.scrollViewClassName }>

--- a/packages/component/src/EventSpy.js
+++ b/packages/component/src/EventSpy.js
@@ -58,6 +58,8 @@ export default class EventSpy extends React.Component {
   }
 
   handleEvent(event) {
+    event.timeStampLow = Date.now();
+
     this.debouncer(event);
   }
 

--- a/packages/component/src/ScrollToBottom/AutoHideFollowButton.js
+++ b/packages/component/src/ScrollToBottom/AutoHideFollowButton.js
@@ -28,7 +28,7 @@ const ROOT_CSS = css({
 
 export default ({ children, className }) =>
   <StateContext.Consumer>
-    { ({ animating, atEnd }) => !animating && !atEnd &&
+    { ({ sticky }) => !sticky &&
       <FunctionContext.Consumer>
         { ({ scrollToEnd }) =>
           <button

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -207,7 +207,7 @@ export default class Composer extends React.Component {
 }
 
 Composer.defaultProps = {
-  checkInterval: 100,
+  checkInterval: 150,
   debounce: 17
 };
 

--- a/packages/component/src/ScrollToBottom/Panel.js
+++ b/packages/component/src/ScrollToBottom/Panel.js
@@ -10,31 +10,19 @@ const ROOT_CSS = css({
   width: '100%'
 });
 
-class Panel extends React.Component {
-  componentDidUpdate() {
-    this.props.handleUpdate();
-  }
-
-  render() {
-    const { props } = this;
-
-    return (
-      <div
-        className={ classNames(ROOT_CSS + '', (props.className || '') + '') }
-        ref={ props.setTarget }
-      >
-        { props.children }
-      </div>
-    );
-  }
-}
+const Panel = ({ children, className, setTarget }) =>
+  <div
+    className={ classNames(ROOT_CSS + '', (className || '') + '') }
+    ref={ setTarget }
+  >
+    { children }
+  </div>
 
 export default props =>
   <InternalContext.Consumer>
-    { ({ _handleUpdate, _setTarget }) =>
+    { ({ setTarget }) =>
       <Panel
-        handleUpdate={ _handleUpdate }
-        setTarget={ _setTarget }
+        setTarget={ setTarget }
         { ...props }
       />
     }

--- a/packages/component/src/ScrollToBottom/StateContext.js
+++ b/packages/component/src/ScrollToBottom/StateContext.js
@@ -4,8 +4,7 @@ const context = React.createContext({
   atBottom: true,
   atEnd: true,
   atTop: true,
-  mode: 'bottom',
-  threshold: 10
+  mode: 'bottom'
 });
 
 context.displayName = 'ScrollToBottomStateContext';

--- a/packages/component/src/SpineTo.js
+++ b/packages/component/src/SpineTo.js
@@ -31,18 +31,18 @@ export default class ScrollTo extends React.Component {
   }
 
   componentDidMount() {
-    const { name, target } = this.props;
+    const { name, target, value } = this.props;
 
     if (target) {
       this.addEventListeners(target);
-      this.animate(name, target[name], this.props.value, 1);
+      this.animate(name, target[name], value, 1);
     }
   }
 
   componentDidUpdate(prevProps) {
+    const { props: { name, target, value } } = this;
     const { target: prevTarget } = prevProps;
-    const { target } = this.props;
-    const scrollChanged = prevProps.value !== this.props.value;
+    const scrollChanged = prevProps.value !== value;
     const targetChanged = prevTarget !== target;
 
     if (targetChanged) {
@@ -51,9 +51,7 @@ export default class ScrollTo extends React.Component {
     }
 
     if ((scrollChanged || targetChanged) && target) {
-      const { name } = this.props;
-
-      this.animate(name, target[name], this.props.value, 1);
+      this.animate(name, target[name], value, 1);
     }
   }
 
@@ -71,26 +69,23 @@ export default class ScrollTo extends React.Component {
   }
 
   animate(name, from, to, index, start = Date.now()) {
-    if (to === 'bottom' || typeof to === 'number') {
+    if (to === '100%' || typeof to === 'number') {
       cancelAnimationFrame(this.animator);
 
       this.animator = requestAnimationFrame(() => {
         const { target } = this.props;
 
         if (target) {
-          if (to === 'bottom') {
-            to = target.scrollHeight - target.offsetHeight
-          }
+          const toNumber = to === '100%' ? target.scrollHeight - target.offsetHeight : to;
+          let nextValue = step(from, toNumber, squareStepper, (Date.now() - start) / 5);
 
-          let nextValue = step(from, to, squareStepper, (Date.now() - start) / 5);
-
-          if (Math.abs(to - nextValue) < .5) {
-            nextValue = to;
+          if (Math.abs(toNumber - nextValue) < .5) {
+            nextValue = toNumber;
           }
 
           target[name] = nextValue;
 
-          if (to === nextValue) {
+          if (toNumber === nextValue) {
             this.props.onEnd && this.props.onEnd(true);
           } else {
             this.animate(name, from, to, index + 1, start);
@@ -116,6 +111,6 @@ ScrollTo.propTypes = {
   target: PropTypes.any.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.oneOf(['bottom'])
+    PropTypes.oneOf(['100%'])
   ]).isRequired
 };

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -1,8 +1,9 @@
 import { css } from 'glamor';
+import classNames from 'classnames';
 import Interval from 'react-interval';
 import loremIpsum from 'lorem-ipsum';
 import React from 'react';
-import ScrollToEnd from 'react-scroll-to-bottom';
+import ScrollToEnd, { StateContext } from 'react-scroll-to-bottom';
 
 const FADE_IN_ANIMATION = css.keyframes({
   '0%': { opacity: .2 },
@@ -49,6 +50,10 @@ const SCROLL_VIEW_CSS = css({
 const SCROLL_VIEW_PADDING_CSS = css({
   paddingLeft: 10,
   paddingRight: 10,
+
+  '&:not(.sticky)': {
+    backgroundColor: 'rgba(255, 0, 0, .1)'
+  },
 
   '& > p': {
     animation: `${ FADE_IN_ANIMATION } 500ms`
@@ -122,14 +127,22 @@ class App extends React.Component {
         </ul>
         <div className="panes">
           <ScrollToEnd className={ CONTAINER_CSS } scrollViewClassName={ SCROLL_VIEW_CSS }>
-            <div className={ SCROLL_VIEW_PADDING_CSS }>
-              { this.state.paragraphs.map(paragraph => <p key={ paragraph }>{ paragraph }</p>) }
-            </div>
+            <StateContext.Consumer>
+              { ({ sticky }) =>
+                <div className={ classNames(SCROLL_VIEW_PADDING_CSS + '', { sticky }) }>
+                  { this.state.paragraphs.map(paragraph => <p key={ paragraph }>{ paragraph }</p>) }
+                </div>
+              }
+            </StateContext.Consumer>
           </ScrollToEnd>
           <ScrollToEnd className={ CONTAINER_CSS } mode="top">
-            <div className={ SCROLL_VIEW_PADDING_CSS }>
-              { [...this.state.paragraphs].reverse().map(paragraph => <p key={ paragraph }>{ paragraph }</p>) }
-            </div>
+            <StateContext.Consumer>
+              { ({ sticky }) =>
+                <div className={ classNames(SCROLL_VIEW_PADDING_CSS + '', { sticky }) }>
+                  { [...this.state.paragraphs].reverse().map(paragraph => <p key={ paragraph }>{ paragraph }</p>) }
+                </div>
+              }
+            </StateContext.Consumer>
           </ScrollToEnd>
         </div>
         { this.state.intervalEnabled &&


### PR DESCRIPTION
Instead of using `componentWillUpdate` to detect if content is updated, we use `setInterval` for "stickiness check".

This is more reliable way because it can handle all types of content update, especially `HTMLImageElement.onload` event.

## Changelog

### Changed
- Update algorithm, instead of using `componentDidUpdate`, we now use `setInterval` to check if the panel is sticky or not, this help to track content update that happen outside of React lifecycle, for example, `HTMLImageElement.onload` event
- `scrollTo()` now accepts `"100%"` instead of `"bottom"`

### Removed
- Removed `threshold` props because the algorithm is now more robust
