### PR TITLE
Add scroller prop to programmatically pause scrolling and `initialScrollBehavior`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.1.0] - 2020-12-31
+
+### Added
+
+- Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+
+### Fixed
+
+- Emptying container should regain stickiness, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+
 ## [4.0.0] - 2020-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
 - Added `initialScrollBehavior` prop for first scroll behavior. When set to `"auto"` (discrete scrolling), it will jump to end on initialization. in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+- Added `debug` prop for dumping debug log to console, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+- Improved performance by separating `StateContext` into 2 tiers, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [4.1.0] - 2020-12-31
-
 ### Added
 
 - Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+- Added `initialScrollBehavior` prop for first scroll behavior. When set to `"auto"` (discrete scrolling), it will jump to end on initialization. in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
-- Added `initialScrollBehavior` prop for first scroll behavior. When set to `"auto"` (discrete scrolling), it will jump to end on initialization. in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
-- Added `debug` prop for dumping debug log to console, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
-- Improved performance by separating `StateContext` into 2 tiers, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+- Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
+- Added `initialScrollBehavior` prop for first scroll behavior. When set to `"auto"` (discrete scrolling), it will jump to end on initialization. in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
+- Added `debug` prop for dumping debug log to console, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
+- Improved performance by separating `StateContext` into 2 tiers, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
 
 ### Fixed
 
-- Emptying container should regain stickiness, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX)
+- Emptying container should regain stickiness, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
 
 ## [4.0.0] - 2020-09-01
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,17 @@ export default props => (
 
 ## Props
 
-| Name                    | Type     | Default    | Description                                                                                                                    |
-| ----------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `checkInterval`         | `number` | 150        | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)                                                     |
-| `className`             | `string` |            | Set the class name for the root element                                                                                        |
-| `debounce`              | `number` | `17`       | Set the debounce for tracking the `onScroll` event                                                                             |
-| `followButtonClassName` | `string` |            | Set the class name for the follow button                                                                                       |
-| `mode`                  | `string` | `"bottom"` | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top                                                           |
-| `nonce`                 | `string` |            | Set the nonce for [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) |
-| `scrollViewClassName`   | `string` |            | Set the class name for the container element that house all `props.children`                                                   |
+| Name                    | Type       | Default          | Description                                                                                                                    |
+| ----------------------- | ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `checkInterval`         | `number`   | 150              | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)                                                     |
+| `className`             | `string`   |                  | Set the class name for the root element                                                                                        |
+| `debounce`              | `number`   | `17`             | Set the debounce for tracking the `onScroll` event                                                                             |
+| `followButtonClassName` | `string`   |                  | Set the class name for the follow button                                                                                       |
+| `initialScrollBehavior` | `string`   | `smooth`         | Set the initial scroll behavior, either `"auto"` (discrete scrolling) or `"smooth"`                                            |
+| `mode`                  | `string`   | `"bottom"`       | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top                                                           |
+| `nonce`                 | `string`   |                  | Set the nonce for [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) |
+| `scroller`              | `function` | `() => Infinity` | A function to determine how far should scroll when scroll is needed                                                            |
+| `scrollViewClassName`   | `string`   |                  | Set the class name for the container element that house all `props.children`                                                   |
 
 ## Hooks
 
@@ -368,6 +370,32 @@ export default () => (
   </ScrollToBottom>
 );
 ```
+
+## Programmatically pausing scroll
+
+> This only works when `mode` prop is set to `bottom` (default).
+
+You can pass a function to the `scroller` prop to customize how far to scroll (in pixel) when the content changed. The signature of the scroller function is:
+
+```js
+scroller({ maxValue, minValue, offsetHeight, scrollHeight, scrollTop }) => number;
+```
+
+| Argument       | Type     | Description                                                                                |
+| -------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `maxValue`     | `number` | Maximum distance (in pixel) to scroll                                                      |
+| `minValue`     | `number` | Minimum distance (in pixel) to scroll, see notes below                                     |
+| `offsetHeight` | `number` | View height of the scrollable container                                                    |
+| `scrollHeight` | `number` | Total height of the content in the container, must be equal or greater than `offsetHeight` |
+| `scrollTop`    | `number` | Current scroll position (in pixel)                                                         |
+
+Note: the `scroller` function will get called when the scrollable is sticky and the content size change. If the scrollable is not sticky, the function will not be called as animation is not needed.
+
+When the scrollable is animating, if there are new contents added to the scrollable, the `scroller` function will get called again with `minValue` set to the current position. The `minValue` means how far the animation has already scrolled.
+
+By default, the `scroller` function will returns `Infinity`. When new content is added, it will scroll all the way to the bottom.
+
+You can return a different value (in number) to indicates how far you want to scroll when the content has changed. If you return `0`, the scrollable will stop scrolling for any new content. Returning any values less than `maxValue` will make the scrollable to lose its stickiness after animation. After the scrollable lose its stickiness, the `scroller` function will not be called again for any future content change, until the scrollable regains its stickiness.
 
 # Security
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ export default () => (
 
 > This only works when `mode` prop is set to `bottom` (default).
 
-You can pass a function to the `scroller` prop to customize how far to scroll (in pixel) when the content changed. The signature of the scroller function is:
+You can pass a function to the `scroller` prop to customize how far the scrollable should animate/scroll (in pixel) when its content changed. The signature of the scroller function is:
 
 ```js
 scroller({ maxValue, minValue, offsetHeight, scrollHeight, scrollTop }) => number;

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ export default () => (
 You can use `useObserveScrollPosition` to listen to scroll change.
 
 ```js
-// ThisA is the content rendered inside the scrollable container
+// This is the content rendered inside the scrollable container
 const ScrollContent = () => {
   const observer = useCallback(({ scrollTop }) => {
     console.log(scrollTop);

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ export default props => (
 | `checkInterval`         | `number`   | 150              | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)                                                     |
 | `className`             | `string`   |                  | Set the class name for the root element                                                                                        |
 | `debounce`              | `number`   | `17`             | Set the debounce for tracking the `onScroll` event                                                                             |
+| `debug`                 | `bool`     | false            | Show debug information in console                                                                                              |
 | `followButtonClassName` | `string`   |                  | Set the class name for the follow button                                                                                       |
 | `initialScrollBehavior` | `string`   | `smooth`         | Set the initial scroll behavior, either `"auto"` (discrete scrolling) or `"smooth"`                                            |
 | `mode`                  | `string`   | `"bottom"`       | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top                                                           |

--- a/README.md
+++ b/README.md
@@ -372,6 +372,34 @@ export default () => (
 );
 ```
 
+## Observing scroll position
+
+You can use `useObserveScrollPosition` to listen to scroll change.
+
+```js
+// ThisA is the content rendered inside the scrollable container
+const ScrollContent = () => {
+  const observer = useCallback(({ scrollTop }) => {
+    console.log(scrollTop);
+  }, []);
+
+  useObserveScrollPosition(observer);
+
+  return <div>Hello, World!</div>;
+};
+```
+
+> If you want to turn off the hook, in the render call, pass a falsy value, e.g. `useObserveScrollPosition(false)`.
+
+Please note that the observer will called very frequently, it is recommended:
+
+- Only observe the scroll position when needed
+- Don't put too much logic inside the callback function
+- If logic is needed, consider deferring handling using `setTimeout` or similar functions
+- Make sure the callback function passed on each render call is memoized appropriately, e.g. `useCallback`
+
+For best practices on handling `scroll` event, please read [this article](https://developer.mozilla.org/en-US/docs/Web/API/Document/scroll_event).
+
 ## Programmatically pausing scroll
 
 > This only works when `mode` prop is set to `bottom` (default).

--- a/TESTS.md
+++ b/TESTS.md
@@ -4,38 +4,58 @@
 
 These are tests for regressions.
 
+Assumptions:
+
+- The container size is `500px`
+- Each element size is default at `100px` (unless specified)
+- The container contains 10 elements and is sticky
+
 ### Add elements quickly
 
-- [ ] Add 10 elements very quickly
+> Press and hold <kbd>1</kbd> in playground for a few seconds.
+
+- [ ] Add 20+ elements very quickly
 - [ ] Test it again on Firefox
 
 Expect:
+
 - It should not lose stickiness
 - During elements add, it should not lose stickiness for a split second
-   - In playground, it should not turn pink at any moments
+  - In playground, it should not turn pink at any moments
 
 ### Scroller
 
 - [ ] Set a scroller of `100px`
 - [ ] Add 1 element of `50px`
 - [ ] Add another element of `200px` very quickly after the previous one
-   - Preferably, use `requestAnimationFrame`
+  - Preferably, use `requestAnimationFrame`
 
 Expect:
+
 - It should stop at 100px
 
 ### Resizing container
 
-> Press `4-1-5-1-1` in the playground.
+> Press <kbd>4</kbd> <kbd>1</kbd> <kbd>5</kbd> <kbd>1</kbd> <kbd>1</kbd> in the playground.
+
+- [ ] Change the container size to `200px`
+- [ ] Add an element
+- [ ] Change the container size back to `500px`
+- [ ] Add 2 elements
+
+Expect:
+
+- It should not lose stickiness during the whole test
 
 ### Focusing to an interactive element
 
-- [ ] Add 10 elements of each `100px`
+- [ ] Add 10 elements
 - [ ] Scroll to top (losing stickiness)
 - [ ] Add a `<button>` to the very bottom
-- [ ] Focus to the button
+- [ ] Press <kbd>TAB</kbd> to focus on the button
 
 Expect:
+
 - Browser will scroll down to show the button
 - It should become sticky as it is on the bottom of the screen now
 
@@ -45,4 +65,15 @@ Expect:
 - [ ] Add an element
 
 Expect:
-- It should lose stickiness
+
+- It should lose stickiness after adding an element
+
+### Emptying the container
+
+- [ ] Scroll up and lose stickiness
+- [ ] Clear the container
+- [ ] Add 10 elements
+
+Expect:
+
+- It should retain stickiness after the container is emptied

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,48 @@
+# Manual tests
+
+## Quirks
+
+These are tests for regressions.
+
+### Add elements quickly
+
+- [ ] Add 10 elements very quickly
+- [ ] Test it again on Firefox
+
+Expect:
+- It should not lose stickiness
+- During elements add, it should not lose stickiness for a split second
+   - In playground, it should not turn pink at any moments
+
+### Scroller
+
+- [ ] Set a scroller of `100px`
+- [ ] Add 1 element of `50px`
+- [ ] Add another element of `200px` very quickly after the previous one
+   - Preferably, use `requestAnimationFrame`
+
+Expect:
+- It should stop at 100px
+
+### Resizing container
+
+> Press `4-1-5-1-1` in the playground.
+
+### Focusing to an interactive element
+
+- [ ] Add 10 elements of each `100px`
+- [ ] Scroll to top (losing stickiness)
+- [ ] Add a `<button>` to the very bottom
+- [ ] Focus to the button
+
+Expect:
+- Browser will scroll down to show the button
+- It should become sticky as it is on the bottom of the screen now
+
+### Scroll to pause scrolling
+
+- [ ] Set a scroller of `0px`
+- [ ] Add an element
+
+Expect:
+- It should lose stickiness

--- a/TESTS.md
+++ b/TESTS.md
@@ -77,3 +77,14 @@ Expect:
 Expect:
 
 - It should retain stickiness after the container is emptied
+
+### Scroll to bottom while at bottom
+
+- [ ] Show command bar
+- [ ] Scroll to bottom, it should gain stickiness
+- [ ] Uncheck "Smooth" checkbox
+- [ ] Click the "Scroll to end" button multiple times
+
+Expect:
+
+- It should not lose stickiness after clicking on the "Scroll to end" button multiple times

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -41,6 +41,7 @@ const BasicScrollToBottom = ({
   children,
   className,
   debounce,
+  debug,
   followButtonClassName,
   initialScrollBehavior,
   mode,
@@ -52,6 +53,7 @@ const BasicScrollToBottom = ({
     <Composer
       checkInterval={checkInterval}
       debounce={debounce}
+      debug={debug}
       initialScrollBehavior={initialScrollBehavior}
       mode={mode}
       nonce={nonce}
@@ -73,8 +75,9 @@ BasicScrollToBottom.defaultProps = {
   children: undefined,
   className: undefined,
   debounce: undefined,
+  debug: false,
   followButtonClassName: undefined,
-  initialScrollBehavior: false,
+  initialScrollBehavior: 'smooth',
   mode: undefined,
   nonce: undefined,
   scrollViewClassName: undefined
@@ -85,6 +88,7 @@ BasicScrollToBottom.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
   debounce: PropTypes.number,
+  debug: PropTypes.bool,
   followButtonClassName: PropTypes.string,
   initialScrollBehavior: PropTypes.oneOf(['auto', 'smooth']),
   mode: PropTypes.oneOf(['bottom', 'top']),

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -44,10 +44,11 @@ const BasicScrollToBottom = ({
   followButtonClassName,
   mode,
   nonce,
+  scroller,
   scrollViewClassName
 }) => {
   return (
-    <Composer checkInterval={checkInterval} debounce={debounce} mode={mode} nonce={nonce}>
+    <Composer checkInterval={checkInterval} debounce={debounce} mode={mode} nonce={nonce} scroller={scroller}>
       <BasicScrollToBottomCore
         className={className}
         followButtonClassName={followButtonClassName}

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -42,13 +42,21 @@ const BasicScrollToBottom = ({
   className,
   debounce,
   followButtonClassName,
+  initialScrollBehavior,
   mode,
   nonce,
   scroller,
   scrollViewClassName
 }) => {
   return (
-    <Composer checkInterval={checkInterval} debounce={debounce} mode={mode} nonce={nonce} scroller={scroller}>
+    <Composer
+      checkInterval={checkInterval}
+      debounce={debounce}
+      initialScrollBehavior={initialScrollBehavior}
+      mode={mode}
+      nonce={nonce}
+      scroller={scroller}
+    >
       <BasicScrollToBottomCore
         className={className}
         followButtonClassName={followButtonClassName}
@@ -66,6 +74,7 @@ BasicScrollToBottom.defaultProps = {
   className: undefined,
   debounce: undefined,
   followButtonClassName: undefined,
+  initialScrollBehavior: false,
   mode: undefined,
   nonce: undefined,
   scrollViewClassName: undefined
@@ -77,6 +86,7 @@ BasicScrollToBottom.propTypes = {
   className: PropTypes.string,
   debounce: PropTypes.number,
   followButtonClassName: PropTypes.string,
+  initialScrollBehavior: PropTypes.oneOf(['auto', 'smooth']),
   mode: PropTypes.oneOf(['bottom', 'top']),
   nonce: PropTypes.string,
   scrollViewClassName: PropTypes.string

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -8,7 +8,8 @@ import EventSpy from '../EventSpy';
 import FunctionContext from './FunctionContext';
 import InternalContext from './InternalContext';
 import SpineTo from '../SpineTo';
-import StateContext from './StateContext';
+import State1Context from './State1Context';
+import State2Context from './State2Context';
 import styleConsole from '../utils/styleConsole';
 
 const DEFAULT_SCROLLER = () => Infinity;
@@ -97,7 +98,12 @@ const Composer = ({
   );
 
   const handleSpineToEnd = useCallback(() => {
-    debug('%cSpineTo%c: %conEnd%c is fired.', ...styleConsole('magenta'), ...styleConsole('orange'), { animateTo });
+    debug(() => [
+      '%cSpineTo%c: %conEnd%c is fired.',
+      ...styleConsole('magenta'),
+      ...styleConsole('orange'),
+      { animateTo }
+    ]);
 
     ignoreScrollEventBeforeRef.current = Date.now();
 
@@ -123,7 +129,7 @@ const Composer = ({
 
       // If it is trying to scroll to a position which is not "atEnd", it should set sticky to false after scroll ended.
 
-      debug(
+      debug(() => [
         [
           `%cscrollTo%c: Will scroll to %c${
             typeof nextAnimateTo === 'number' ? nextAnimateTo + 'px' : nextAnimateTo.replace(/%/gu, '%%')
@@ -136,7 +142,7 @@ const Composer = ({
           nextAnimateTo,
           target
         }
-      );
+      ]);
 
       if (behavior === 'auto') {
         // Stop any existing animation
@@ -163,7 +169,7 @@ const Composer = ({
 
   const scrollToBottom = useCallback(
     ({ behavior } = {}) => {
-      debug('%cscrollToBottom%c: Called', ...styleConsole('yellow', ''));
+      debug(() => ['%cscrollToBottom%c: Called', ...styleConsole('yellow', '')]);
 
       behavior !== 'smooth' &&
         console.warn(
@@ -177,7 +183,7 @@ const Composer = ({
 
   const scrollToTop = useCallback(
     ({ behavior } = {}) => {
-      debug('%cscrollToTop%c: Called', ...styleConsole('yellow', ''));
+      debug(() => ['%cscrollToTop%c: Called', ...styleConsole('yellow', '')]);
 
       behavior !== 'smooth' &&
         console.warn(
@@ -191,7 +197,7 @@ const Composer = ({
 
   const scrollToEnd = useCallback(
     ({ behavior } = {}) => {
-      debug('%cscrollToEnd%c: Called', ...styleConsole('yellow', ''));
+      debug(() => ['%cscrollToEnd%c: Called', ...styleConsole('yellow', '')]);
 
       behavior !== 'smooth' &&
         console.warn(
@@ -207,7 +213,7 @@ const Composer = ({
 
   const scrollToStart = useCallback(
     ({ behavior } = {}) => {
-      debug('%cscrollToStart%c: Called', ...styleConsole('yellow', ''));
+      debug(() => ['%cscrollToStart%c: Called', ...styleConsole('yellow', '')]);
 
       behavior !== 'smooth' &&
         console.warn(
@@ -224,7 +230,7 @@ const Composer = ({
   const scrollToSticky = useCallback(() => {
     if (target) {
       if (initialScrollBehaviorRef.current === 'auto') {
-        debug(`%ctarget changed%c: Initial scroll`, ...styleConsole('blue'));
+        debug(() => [`%ctarget changed%c: Initial scroll`, ...styleConsole('blue')]);
 
         target.scrollTop = mode === MODE_TOP ? 0 : target.scrollHeight - target.offsetHeight;
         initialScrollBehaviorRef.current = false;
@@ -257,7 +263,7 @@ const Composer = ({
         nextAnimateTo = '100%';
       }
 
-      debug(
+      debug(() => [
         [
           `%cscrollToSticky%c: Will animate from %c${animateFrom}px%c to %c${
             typeof nextAnimateTo === 'number' ? nextAnimateTo + 'px' : nextAnimateTo.replace(/%/gu, '%%')
@@ -278,7 +284,7 @@ const Composer = ({
           scrollHeight,
           scrollTop
         }
-      );
+      ]);
 
       scrollTo(nextAnimateTo, { behavior: 'smooth' });
     }
@@ -334,7 +340,7 @@ const Composer = ({
         const nextSticky = (animating && isEnd(animateTo, mode)) || atEnd;
 
         if (sticky !== nextSticky) {
-          debug(
+          debug(() => [
             [
               `%conScroll%c: %csetSticky%c(%c${nextSticky}%c)`,
               ...styleConsole('red'),
@@ -357,12 +363,12 @@ const Composer = ({
                 nextSticky
               }
             ]
-          );
+          ]);
 
           setSticky(nextSticky);
         }
       } else if (sticky) {
-        debug(
+        debug(() => [
           [
             `%conScroll%c: Size changed while sticky, calling %cscrollToSticky()%c`,
             ...styleConsole('red'),
@@ -378,7 +384,7 @@ const Composer = ({
             nextScrollHeight,
             prevScrollHeight: scrollHeight
           }
-        );
+        ]);
 
         scrollToSticky();
       }
@@ -427,11 +433,11 @@ const Composer = ({
               if (!animating) {
                 animateFromRef.current = target.scrollTop;
 
-                debug(
+                debug(() => [
                   `%cInterval check%c: Should sticky but not at end, calling %cscrollToSticky()%c to scroll`,
                   ...styleConsole('navy'),
                   ...styleConsole('orange')
-                );
+                ]);
 
                 scrollToSticky();
               }
@@ -450,7 +456,7 @@ const Composer = ({
 
       return () => clearInterval(timeout);
     }
-  }, [animating, checkInterval, mode, scroller, scrollToSticky, setSticky, sticky, target]);
+  }, [animating, checkInterval, mode, scrollToSticky, setSticky, sticky, target]);
 
   const styleToClassName = useMemo(() => {
     const emotion =
@@ -469,18 +475,24 @@ const Composer = ({
     [observeScrollPosition, setTarget, styleToClassName]
   );
 
-  const stateContext = useMemo(
+  const state1Context = useMemo(
     () => ({
-      animating,
-      animatingToEnd: animating && isEnd(animateTo, mode),
       atBottom,
       atEnd,
       atStart,
       atTop,
-      mode,
+      mode
+    }),
+    [atBottom, atEnd, atStart, atTop, mode]
+  );
+
+  const state2Context = useMemo(
+    () => ({
+      animating,
+      animatingToEnd: animating && isEnd(animateTo, mode),
       sticky
     }),
-    [animating, animateTo, atBottom, atEnd, atStart, atTop, mode, sticky]
+    [animating, animateTo, sticky]
   );
 
   const functionContext = useMemo(
@@ -525,23 +537,28 @@ const Composer = ({
     }
   }, [target]);
 
-  debug([`%cRender%c: Render`, ...styleConsole('cyan', '')], {
-    animateTo,
-    animating,
-    sticky,
-    target
-  });
+  debug(() => [
+    [`%cRender%c: Render`, ...styleConsole('cyan', '')],
+    {
+      animateTo,
+      animating,
+      sticky,
+      target
+    }
+  ]);
 
   return (
     <InternalContext.Provider value={internalContext}>
       <FunctionContext.Provider value={functionContext}>
-        <StateContext.Provider value={stateContext}>
-          {children}
-          {target && <EventSpy debounce={debounce} name="scroll" onEvent={handleScroll} target={target} />}
-          {target && animateTo !== null && (
-            <SpineTo name="scrollTop" onEnd={handleSpineToEnd} target={target} value={animateTo} />
-          )}
-        </StateContext.Provider>
+        <State1Context.Provider value={state1Context}>
+          <State2Context.Provider value={state2Context}>
+            {children}
+            {target && <EventSpy debounce={debounce} name="scroll" onEvent={handleScroll} target={target} />}
+            {target && animateTo !== null && (
+              <SpineTo name="scrollTop" onEnd={handleSpineToEnd} target={target} value={animateTo} />
+            )}
+          </State2Context.Provider>
+        </State1Context.Provider>
       </FunctionContext.Provider>
     </InternalContext.Provider>
   );

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -10,7 +10,7 @@ import InternalContext from './InternalContext';
 import SpineTo from '../SpineTo';
 import State1Context from './State1Context';
 import State2Context from './State2Context';
-import StateContext from '../StateContext';
+import StateContext from './StateContext';
 import styleConsole from '../utils/styleConsole';
 
 const DEFAULT_SCROLLER = () => Infinity;

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -49,10 +49,11 @@ function isEnd(animateTo, mode) {
   return animateTo === (mode === MODE_TOP ? 0 : '100%');
 }
 
-const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) => {
+const Composer = ({ checkInterval, children, debounce, initialScrollBehavior, mode, nonce, scroller }) => {
   mode = mode === MODE_TOP ? MODE_TOP : MODE_BOTTOM;
 
   const ignoreScrollEventBeforeRef = useRef(0);
+  const initialScrollBehaviorRef = useRef(initialScrollBehavior);
   const [animateTo, setAnimateTo] = useState(mode === MODE_TOP ? 0 : '100%');
   const [target, setTarget] = useState(null);
 
@@ -204,6 +205,15 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
   const scrollToSticky = useCallback(() => {
     if (target) {
+      if (initialScrollBehaviorRef.current === 'auto') {
+        debug(`%ctarget changed%c: Initial scroll`, ...styleConsole('blue'));
+
+        target.scrollTop = mode === MODE_TOP ? 0 : target.scrollHeight - target.offsetHeight;
+        initialScrollBehaviorRef.current = false;
+
+        return;
+      }
+
       // This is very similar to scrollToEnd().
       // Instead of scrolling to end, it will call props.scroller() to determines how far it should scroll.
       // This function could be called while it is auto-scrolling.
@@ -523,6 +533,7 @@ Composer.defaultProps = {
   checkInterval: 100,
   children: undefined,
   debounce: 17,
+  initialScrollBehavior: false,
   mode: undefined,
   nonce: undefined,
   scroller: DEFAULT_SCROLLER
@@ -532,6 +543,7 @@ Composer.propTypes = {
   checkInterval: PropTypes.number,
   children: PropTypes.any,
   debounce: PropTypes.number,
+  initialScrollBehavior: PropTypes.oneOf(['auto', 'smooth']),
   mode: PropTypes.oneOf(['bottom', 'top']),
   nonce: PropTypes.string,
   scroller: PropTypes.func

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -107,6 +107,10 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
   // Function context
   const scrollTo = useCallback(
     (nextAnimateTo, { behavior } = {}) => {
+      if (typeof nextAnimateTo !== 'number' && nextAnimateTo !== '100%') {
+        return console.warn('react-scroll-to-bottom: Arguments passed to scrollTo() must be either number or "100%".');
+      }
+
       // If it is trying to scroll to a position which is not "atEnd", it should set sticky to false after scroll ended.
 
       debug(
@@ -373,43 +377,50 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
   );
 
   useEffect(() => {
-    if (sticky) {
+    if (target) {
       let stickyButNotAtEndSince = false;
 
       const timeout = setImmediateInterval(() => {
-        if (sticky && target && !computeViewState({ mode, target }).atEnd) {
-          if (!stickyButNotAtEndSince) {
-            stickyButNotAtEndSince = Date.now();
-          } else if (Date.now() - stickyButNotAtEndSince > SCROLL_DECISION_DURATION) {
-            // Quirks: In Firefox, after user scroll down, Firefox do two things:
-            //         1. Set to a new "scrollTop"
-            //         2. Fire "scroll" event
-            //         For what we observed, #1 is fired about 20ms before #2. There is a chance that this stickyCheckTimeout is being scheduled between 1 and 2.
-            //         That means, if we just look at #1 to decide if we should scroll, we will always scroll, in oppose to the user's intention.
-            // Repro: Open Firefox, set checkInterval to a lower number, and try to scroll by dragging the scroll handler. It will jump back.
+        if (sticky) {
+          if (!computeViewState({ mode, target }).atEnd) {
+            if (!stickyButNotAtEndSince) {
+              stickyButNotAtEndSince = Date.now();
+            } else if (Date.now() - stickyButNotAtEndSince > SCROLL_DECISION_DURATION) {
+              // Quirks: In Firefox, after user scroll down, Firefox do two things:
+              //         1. Set to a new "scrollTop"
+              //         2. Fire "scroll" event
+              //         For what we observed, #1 is fired about 20ms before #2. There is a chance that this stickyCheckTimeout is being scheduled between 1 and 2.
+              //         That means, if we just look at #1 to decide if we should scroll, we will always scroll, in oppose to the user's intention.
+              // Repro: Open Firefox, set checkInterval to a lower number, and try to scroll by dragging the scroll handler. It will jump back.
 
-            // The "animating" check will make sure stickiness is not lost when elements are adding at a very fast pace.
-            if (!animating) {
-              animateFromRef.current = target.scrollTop;
+              // The "animating" check will make sure stickiness is not lost when elements are adding at a very fast pace.
+              if (!animating) {
+                animateFromRef.current = target.scrollTop;
 
-              debug(
-                `%cInterval check%c: Should sticky but not at end, calling %cscrollToSticky()%c to scroll`,
-                ...styleConsole('navy'),
-                ...styleConsole('orange')
-              );
+                debug(
+                  `%cInterval check%c: Should sticky but not at end, calling %cscrollToSticky()%c to scroll`,
+                  ...styleConsole('navy'),
+                  ...styleConsole('orange')
+                );
 
-              scrollToSticky();
+                scrollToSticky();
+              }
+
+              stickyButNotAtEndSince = false;
             }
+          } else {
             stickyButNotAtEndSince = false;
           }
-        } else {
-          stickyButNotAtEndSince = false;
+        } else if (target.scrollHeight <= target.offsetHeight && !sticky) {
+          // When the container is emptied, we will set sticky back to true.
+
+          setSticky(true);
         }
       }, Math.max(MIN_CHECK_INTERVAL, checkInterval) || MIN_CHECK_INTERVAL);
 
       return () => clearInterval(timeout);
     }
-  }, [animating, checkInterval, mode, scroller, scrollToSticky, sticky, target]);
+  }, [animating, checkInterval, mode, scroller, scrollToSticky, setSticky, sticky, target]);
 
   const styleToClassName = useMemo(() => {
     const emotion =

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -118,7 +118,7 @@ const Composer = ({
 
     isEnd(animateTo, mode) || setSticky(false);
     setAnimateTo(null);
-  }, [animateTo, ignoreScrollEventBeforeRef, mode, setAnimateTo, setSticky]);
+  }, [animateTo, debug, ignoreScrollEventBeforeRef, mode, setAnimateTo, setSticky]);
 
   // Function context
   const scrollTo = useCallback(
@@ -164,7 +164,7 @@ const Composer = ({
       // This is for handling a case. When calling scrollTo('100%', { behavior: 'auto' }) multiple times, it would lose stickiness.
       isEnd(nextAnimateTo, mode) && setSticky(true);
     },
-    [handleSpineToEnd, mode, setAnimateTo, setSticky, target]
+    [debug, handleSpineToEnd, mode, setAnimateTo, setSticky, target]
   );
 
   const scrollToBottom = useCallback(
@@ -178,7 +178,7 @@ const Composer = ({
 
       scrollTo('100%', { behavior: behavior || 'smooth' });
     },
-    [scrollTo]
+    [debug, scrollTo]
   );
 
   const scrollToTop = useCallback(
@@ -192,7 +192,7 @@ const Composer = ({
 
       scrollTo(0, { behavior: behavior || 'smooth' });
     },
-    [scrollTo]
+    [debug, scrollTo]
   );
 
   const scrollToEnd = useCallback(
@@ -208,7 +208,7 @@ const Composer = ({
 
       mode === MODE_TOP ? scrollToTop(options) : scrollToBottom(options);
     },
-    [mode, scrollToBottom, scrollToTop]
+    [debug, mode, scrollToBottom, scrollToTop]
   );
 
   const scrollToStart = useCallback(
@@ -224,7 +224,7 @@ const Composer = ({
 
       mode === MODE_TOP ? scrollToBottom(options) : scrollToTop(options);
     },
-    [mode, scrollToBottom, scrollToTop]
+    [debug, mode, scrollToBottom, scrollToTop]
   );
 
   const scrollToSticky = useCallback(() => {
@@ -288,7 +288,7 @@ const Composer = ({
 
       scrollTo(nextAnimateTo, { behavior: 'smooth' });
     }
-  }, [animateFromRef, mode, scroller, scrollTo, target]);
+  }, [animateFromRef, debug, mode, scroller, scrollTo, target]);
 
   const handleScroll = useCallback(
     ({ timeStampLow }) => {
@@ -396,6 +396,7 @@ const Composer = ({
     [
       animateTo,
       animating,
+      debug,
       ignoreScrollEventBeforeRef,
       mode,
       offsetHeightRef,
@@ -456,7 +457,7 @@ const Composer = ({
 
       return () => clearInterval(timeout);
     }
-  }, [animating, checkInterval, mode, scrollToSticky, setSticky, sticky, target]);
+  }, [animating, checkInterval, debug, mode, scrollToSticky, setSticky, sticky, target]);
 
   const styleToClassName = useMemo(() => {
     const emotion =
@@ -492,7 +493,7 @@ const Composer = ({
       animatingToEnd: animating && isEnd(animateTo, mode),
       sticky
     }),
-    [animating, animateTo, sticky]
+    [animating, animateTo, debug, mode, sticky]
   );
 
   const functionContext = useMemo(

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import createCSSKey from '../createCSSKey';
+import createDebug from '../utils/debug';
 import EventSpy from '../EventSpy';
 import FunctionContext from './FunctionContext';
 import InternalContext from './InternalContext';
@@ -16,6 +17,8 @@ const MODE_BOTTOM = 'bottom';
 const MODE_TOP = 'top';
 const NEAR_END_THRESHOLD = 1;
 const SCROLL_DECISION_DURATION = 34; // 2 frames
+
+const debug = createDebug('<ScrollToBottom>');
 
 // We pool the emotion object by nonce.
 // This is to make sure we don't generate too many unneeded <style> tags.
@@ -84,13 +87,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
   );
 
   const handleSpineToEnd = useCallback(() => {
-    console.log(
-      '%c<ScrollToBottom>%c %cSpineTo%c: %conEnd%c is fired.',
-      ...styleConsole('green'),
-      ...styleConsole('magenta'),
-      ...styleConsole('orange'),
-      { animateTo }
-    );
+    debug('%cSpineTo%c: %conEnd%c is fired.', ...styleConsole('magenta'), ...styleConsole('orange'), { animateTo });
 
     ignoreScrollEventBeforeRef.current = Date.now();
 
@@ -112,11 +109,10 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
     (nextAnimateTo, { behavior } = {}) => {
       // If it is trying to scroll to a position which is not "atEnd", it should set sticky to false after scroll ended.
 
-      console.log(
-        `%c<ScrollToBottom>%c %cscrollTo%c: Will scroll to %c${
+      debug(
+        `%cscrollTo%c: Will scroll to %c${
           typeof nextAnimateTo === 'number' ? nextAnimateTo + 'px' : nextAnimateTo.replace(/%/gu, '%%')
         }%c`,
-        ...styleConsole('green'),
         ...styleConsole('lime', ''),
         ...styleConsole('purple')
       );
@@ -141,11 +137,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
   const scrollToBottom = useCallback(
     ({ behavior } = {}) => {
-      console.log(
-        '%c<ScrollToBottom>%c %cscrollToBottom%c: Called',
-        ...styleConsole('green'),
-        ...styleConsole('yellow', '')
-      );
+      debug('%cscrollToBottom%c: Called', ...styleConsole('yellow', ''));
 
       behavior !== 'smooth' &&
         console.warn(
@@ -159,11 +151,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
   const scrollToTop = useCallback(
     ({ behavior } = {}) => {
-      console.log(
-        '%c<ScrollToBottom>%c %cscrollToTop%c: Called',
-        ...styleConsole('green'),
-        ...styleConsole('yellow', '')
-      );
+      debug('%cscrollToTop%c: Called', ...styleConsole('yellow', ''));
 
       behavior !== 'smooth' &&
         console.warn(
@@ -177,11 +165,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
   const scrollToEnd = useCallback(
     ({ behavior } = {}) => {
-      console.log(
-        '%c<ScrollToBottom>%c %cscrollToEnd%c: Called',
-        ...styleConsole('green'),
-        ...styleConsole('yellow', '')
-      );
+      debug('%cscrollToEnd%c: Called', ...styleConsole('yellow', ''));
 
       behavior !== 'smooth' &&
         console.warn(
@@ -197,11 +181,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
   const scrollToStart = useCallback(
     ({ behavior } = {}) => {
-      console.log(
-        '%c<ScrollToBottom>%c %cscrollToStart%c: Called',
-        ...styleConsole('green'),
-        ...styleConsole('yellow', '')
-      );
+      debug('%cscrollToStart%c: Called', ...styleConsole('yellow', ''));
 
       behavior !== 'smooth' &&
         console.warn(
@@ -245,28 +225,26 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
         nextAnimateTo = animateFrom + nextValue;
       }
 
-      console.groupCollapsed(
-        `%c<ScrollToBottom>%c %cscrollToSticky%c: Will animate from %c${animateFrom}px%c to %c${
-          typeof nextAnimateTo === 'number' ? nextAnimateTo + 'px' : nextAnimateTo.replace(/%/gu, '%%')
-        }%c (%c${(nextAnimateTo === '100%' ? maxValue : nextAnimateTo) + animateFrom}px%c)`,
-        ...styleConsole('green'),
-        ...styleConsole('orange'),
-        ...styleConsole('purple'),
-        ...styleConsole('purple'),
-        ...styleConsole('purple')
+      debug(
+        [
+          `%cscrollToSticky%c: Will animate from %c${animateFrom}px%c to %c${
+            typeof nextAnimateTo === 'number' ? nextAnimateTo + 'px' : nextAnimateTo.replace(/%/gu, '%%')
+          }%c (%c${(nextAnimateTo === '100%' ? maxValue : nextAnimateTo) + animateFrom}px%c)`,
+          ...styleConsole('orange'),
+          ...styleConsole('purple'),
+          ...styleConsole('purple'),
+          ...styleConsole('purple')
+        ],
+        {
+          animateFrom,
+          maxValue,
+          minValue,
+          nextAnimateTo,
+          nextScrollBy: nextValue,
+          offsetHeight,
+          scrollHeight
+        }
       );
-
-      console.log({
-        animateFrom,
-        maxValue,
-        minValue,
-        nextAnimateTo,
-        nextScrollBy: nextValue,
-        offsetHeight,
-        scrollHeight
-      });
-
-      console.groupEnd();
 
       scrollTo(nextAnimateTo, { behavior: 'smooth' });
     }
@@ -322,55 +300,51 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
         const nextSticky = (animating && isEnd(animateTo, mode)) || atEnd;
 
         if (sticky !== nextSticky) {
-          console.groupCollapsed(
-            `%c<ScrollToBottom>%c %conScroll%c: %csetSticky%c(%c${nextSticky}%c)`,
-            ...styleConsole('green'),
-            ...styleConsole('red'),
-            ...styleConsole('red'),
-            ...styleConsole('purple')
+          debug(
+            [
+              `%conScroll%c: %csetSticky%c(%c${nextSticky}%c)`,
+              ...styleConsole('red'),
+              ...styleConsole('red'),
+              ...styleConsole('purple')
+            ],
+            [
+              `(animating = %c${animating}%c && isEnd = %c${isEnd(animateTo, mode)}%c) || atEnd = %c${atEnd}%c`,
+              ...styleConsole('purple'),
+              ...styleConsole('purple'),
+              ...styleConsole('purple'),
+              {
+                animating,
+                animateTo,
+                atEnd,
+                mode,
+                offsetHeight: target.offsetHeight,
+                scrollHeight: target.scrollHeight,
+                sticky,
+                nextSticky
+              }
+            ]
           );
-
-          console.log(
-            `(animating = %c${animating}%c && isEnd = %c${isEnd(animateTo, mode)}%c) || atEnd = %c${atEnd}%c`,
-            ...styleConsole('purple'),
-            ...styleConsole('purple'),
-            ...styleConsole('purple'),
-            {
-              animating,
-              animateTo,
-              atEnd,
-              mode,
-              offsetHeight: target.offsetHeight,
-              scrollHeight: target.scrollHeight,
-              sticky,
-              nextSticky
-            }
-          );
-
-          console.groupEnd();
 
           setSticky(nextSticky);
         }
       } else if (sticky) {
-        console.groupCollapsed(
-          `%c<ScrollToBottom>%c %conScroll%c: Size changed while sticky, calling %cscrollToSticky()%c`,
-          ...styleConsole('green'),
-          ...styleConsole('red'),
-          ...styleConsole('orange'),
+        debug(
+          [
+            `%conScroll%c: Size changed while sticky, calling %cscrollToSticky()%c`,
+            ...styleConsole('red'),
+            ...styleConsole('orange'),
+            {
+              offsetHeightChanged,
+              scrollHeightChanged
+            }
+          ],
           {
-            offsetHeightChanged,
-            scrollHeightChanged
+            nextOffsetHeight,
+            prevOffsetHeight: offsetHeight,
+            nextScrollHeight,
+            prevScrollHeight: scrollHeight
           }
         );
-
-        console.log({
-          nextOffsetHeight,
-          prevOffsetHeight: offsetHeight,
-          nextScrollHeight,
-          prevScrollHeight: scrollHeight
-        });
-
-        console.groupEnd();
 
         scrollToSticky();
       }
@@ -418,9 +392,8 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
             if (!animating) {
               animateFromRef.current = target.scrollTop;
 
-              console.log(
-                `%c<ScrollToBottom>%c %cInterval check%c: Should sticky but not at end, calling %cscrollToSticky()%c to scroll`,
-                ...styleConsole('green'),
+              debug(
+                `%cInterval check%c: Should sticky but not at end, calling %cscrollToSticky()%c to scroll`,
                 ...styleConsole('navy'),
                 ...styleConsole('orange')
               );
@@ -511,7 +484,7 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
     }
   }, [target]);
 
-  console.log(`%c<ScrollToBottom>%c %cRender%c: Render`, ...styleConsole('green'), ...styleConsole('cyan', ''), {
+  debug(`%cRender%c: Render`, ...styleConsole('cyan', ''), {
     animateTo,
     animating,
     sticky

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -135,8 +135,11 @@ const Composer = ({ checkInterval, children, debounce, mode, nonce, scroller }) 
 
         setAnimateTo(nextAnimateTo);
       }
+
+      // This is for handling a case. When calling scrollTo('100%', { behavior: 'auto' }) multiple times, it would lose stickiness.
+      isEnd(nextAnimateTo, mode) && setSticky(true);
     },
-    [handleSpineToEnd, setAnimateTo, target]
+    [handleSpineToEnd, mode, setAnimateTo, setSticky, target]
   );
 
   const scrollToBottom = useCallback(

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -10,6 +10,7 @@ import InternalContext from './InternalContext';
 import SpineTo from '../SpineTo';
 import State1Context from './State1Context';
 import State2Context from './State2Context';
+import StateContext from '../StateContext';
 import styleConsole from '../utils/styleConsole';
 
 const DEFAULT_SCROLLER = () => Infinity;
@@ -496,6 +497,14 @@ const Composer = ({
     [animating, animateTo, debug, mode, sticky]
   );
 
+  const combinedStateContext = useMemo(
+    () => ({
+      ...state1Context,
+      ...state2Context
+    }),
+    [state1Context, state2Context]
+  );
+
   const functionContext = useMemo(
     () => ({
       scrollTo,
@@ -551,15 +560,17 @@ const Composer = ({
   return (
     <InternalContext.Provider value={internalContext}>
       <FunctionContext.Provider value={functionContext}>
-        <State1Context.Provider value={state1Context}>
-          <State2Context.Provider value={state2Context}>
-            {children}
-            {target && <EventSpy debounce={debounce} name="scroll" onEvent={handleScroll} target={target} />}
-            {target && animateTo !== null && (
-              <SpineTo name="scrollTop" onEnd={handleSpineToEnd} target={target} value={animateTo} />
-            )}
-          </State2Context.Provider>
-        </State1Context.Provider>
+        <StateContext.Provider value={combinedStateContext}>
+          <State1Context.Provider value={state1Context}>
+            <State2Context.Provider value={state2Context}>
+              {children}
+              {target && <EventSpy debounce={debounce} name="scroll" onEvent={handleScroll} target={target} />}
+              {target && animateTo !== null && (
+                <SpineTo name="scrollTop" onEnd={handleSpineToEnd} target={target} value={animateTo} />
+              )}
+            </State2Context.Provider>
+          </State1Context.Provider>
+        </StateContext.Provider>
       </FunctionContext.Provider>
     </InternalContext.Provider>
   );

--- a/packages/component/src/ScrollToBottom/State1Context.js
+++ b/packages/component/src/ScrollToBottom/State1Context.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const context = React.createContext({
+  atBottom: true,
+  atEnd: true,
+  atStart: false,
+  atTop: true,
+  mode: 'bottom'
+});
+
+context.displayName = 'ScrollToBottomState1Context';
+
+export default context;

--- a/packages/component/src/ScrollToBottom/State2Context.js
+++ b/packages/component/src/ScrollToBottom/State2Context.js
@@ -3,14 +3,9 @@ import React from 'react';
 const context = React.createContext({
   animating: false,
   animatingToEnd: false,
-  atBottom: true,
-  atEnd: true,
-  atStart: false,
-  atTop: true,
-  mode: 'bottom',
   sticky: true
 });
 
-context.displayName = 'ScrollToBottomStateContext';
+context.displayName = 'ScrollToBottomState2Context';
 
 export default context;

--- a/packages/component/src/ScrollToBottom/StateContext.js
+++ b/packages/component/src/ScrollToBottom/StateContext.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const context = React.createContext({
+  animating: false,
+  animatingToEnd: false,
+  atBottom: true,
+  atEnd: true,
+  atStart: false,
+  atTop: true,
+  mode: 'bottom',
+  sticky: true
+});
+
+context.displayName = 'ScrollToBottomStateContext';
+
+export default context;

--- a/packages/component/src/hooks/internal/useStateContext.js
+++ b/packages/component/src/hooks/internal/useStateContext.js
@@ -1,7 +1,8 @@
 import { useContext } from 'react';
 
-import StateContext from '../../ScrollToBottom/StateContext';
+import State1Context from '../../ScrollToBottom/State1Context';
+import State2Context from '../../ScrollToBottom/State2Context';
 
-export default function useStateContext() {
-  return useContext(StateContext);
+export default function useStateContext(tier) {
+  return useContext(tier === 2 ? State2Context : State1Context);
 }

--- a/packages/component/src/hooks/internal/useStateContext.js
+++ b/packages/component/src/hooks/internal/useStateContext.js
@@ -1,8 +1,11 @@
 import { useContext } from 'react';
 
+import StateContext from '../../ScrollToBottom/StateContext';
 import State1Context from '../../ScrollToBottom/State1Context';
 import State2Context from '../../ScrollToBottom/State2Context';
 
+const stateContexts = [StateContext, State1Context, State2Context];
+
 export default function useStateContext(tier) {
-  return useContext(tier === 2 ? State2Context : State1Context);
+  return useContext(stateContexts[tier] || stateContexts[0]);
 }

--- a/packages/component/src/hooks/useAnimating.js
+++ b/packages/component/src/hooks/useAnimating.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAnimating() {
-  const { animating } = useStateContext();
+  const { animating } = useStateContext(2);
 
   return [animating];
 }

--- a/packages/component/src/hooks/useAnimating.js
+++ b/packages/component/src/hooks/useAnimating.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [2] }] */
+
 import useStateContext from './internal/useStateContext';
 
 export default function useAnimating() {

--- a/packages/component/src/hooks/useAnimatingToEnd.js
+++ b/packages/component/src/hooks/useAnimatingToEnd.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAnimatingToEnd() {
-  const { animatingToEnd } = useStateContext();
+  const { animatingToEnd } = useStateContext(2);
 
   return [animatingToEnd];
 }

--- a/packages/component/src/hooks/useAnimatingToEnd.js
+++ b/packages/component/src/hooks/useAnimatingToEnd.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [2] }] */
+
 import useStateContext from './internal/useStateContext';
 
 export default function useAnimatingToEnd() {

--- a/packages/component/src/hooks/useAtBottom.js
+++ b/packages/component/src/hooks/useAtBottom.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAtBottom() {
-  const { atBottom } = useStateContext();
+  const { atBottom } = useStateContext(1);
 
   return [atBottom];
 }

--- a/packages/component/src/hooks/useAtEnd.js
+++ b/packages/component/src/hooks/useAtEnd.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAtEnd() {
-  const { atEnd } = useStateContext();
+  const { atEnd } = useStateContext(1);
 
   return [atEnd];
 }

--- a/packages/component/src/hooks/useAtStart.js
+++ b/packages/component/src/hooks/useAtStart.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAtStart() {
-  const { atStart } = useStateContext();
+  const { atStart } = useStateContext(1);
 
   return [atStart];
 }

--- a/packages/component/src/hooks/useAtTop.js
+++ b/packages/component/src/hooks/useAtTop.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useAtTop() {
-  const { atTop } = useStateContext();
+  const { atTop } = useStateContext(1);
 
   return [atTop];
 }

--- a/packages/component/src/hooks/useMode.js
+++ b/packages/component/src/hooks/useMode.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useMode() {
-  const { mode } = useStateContext();
+  const { mode } = useStateContext(1);
 
   return [mode];
 }

--- a/packages/component/src/hooks/useObserveScrollPosition.js
+++ b/packages/component/src/hooks/useObserveScrollPosition.js
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import useInternalContext from './internal/useInternalContext';
 
 export default function useObserveScrollPosition(observer, deps = []) {
-  if (typeof observer !== 'function') {
+  if (observer && typeof observer !== 'function') {
     console.error('react-scroll-to-bottom: First argument passed to "useObserveScrollPosition" must be a function.');
   } else if (!Array.isArray(deps)) {
     console.error(

--- a/packages/component/src/hooks/useSticky.js
+++ b/packages/component/src/hooks/useSticky.js
@@ -1,7 +1,7 @@
 import useStateContext from './internal/useStateContext';
 
 export default function useSticky() {
-  const { sticky } = useStateContext();
+  const { sticky } = useStateContext(2);
 
   return [sticky];
 }

--- a/packages/component/src/hooks/useSticky.js
+++ b/packages/component/src/hooks/useSticky.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: ["error", { "ignore": [2] }] */
+
 import useStateContext from './internal/useStateContext';
 
 export default function useSticky() {

--- a/packages/component/src/utils/debug.js
+++ b/packages/component/src/utils/debug.js
@@ -19,6 +19,12 @@ export default function debug(category, { force = false } = {}) {
       return;
     }
 
+    const [arg0] = args;
+
+    if (typeof arg0 === 'function') {
+      args = arg0();
+    }
+
     const lines = Array.isArray(args[0]) ? args : [args];
     const oneLiner = lines.length === 1;
 

--- a/packages/component/src/utils/debug.js
+++ b/packages/component/src/utils/debug.js
@@ -9,8 +9,8 @@ function format(category, arg0, ...args) {
   return [`%c${category}%c ${arg0}`, ...styleConsole('green', 'white'), ...args];
 }
 
-export default function debug(category) {
-  if (NODE_ENV !== 'development') {
+export default function debug(category, { force = false } = {}) {
+  if (!force && NODE_ENV !== 'development') {
     return () => 0;
   }
 

--- a/packages/component/src/utils/debug.js
+++ b/packages/component/src/utils/debug.js
@@ -1,0 +1,37 @@
+/* eslint no-console: ["off"] */
+/* global process */
+
+import styleConsole from './styleConsole';
+
+const { NODE_ENV } = (process && process.env) || {};
+
+function format(category, arg0, ...args) {
+  return [`%c${category}%c ${arg0}`, ...styleConsole('green', 'white'), ...args];
+}
+
+export default function debug(category) {
+  if (NODE_ENV !== 'development') {
+    return () => 0;
+  }
+
+  return (...args) => {
+    if (!args.length) {
+      return;
+    }
+
+    const lines = Array.isArray(args[0]) ? args : [args];
+    const oneLiner = lines.length === 1;
+
+    lines.forEach((line, index) => {
+      if (oneLiner) {
+        console.log(...format(category, ...line));
+      } else if (index) {
+        console.log(...(Array.isArray(line) ? line : [line]));
+      } else {
+        console.groupCollapsed(...format(category, ...line));
+      }
+    });
+
+    oneLiner || console.groupEnd();
+  };
+}

--- a/packages/component/src/utils/styleConsole.js
+++ b/packages/component/src/utils/styleConsole.js
@@ -1,0 +1,9 @@
+export default function styleConsole(backgroundColor, color = 'white') {
+  let styles = `background-color: ${backgroundColor}; border-radius: 4px; padding: 2px 4px;`;
+
+  if (color) {
+    styles += ` color: ${color};`;
+  }
+
+  return [styles, ''];
+}

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -117,7 +117,7 @@ const App = ({ nonce }) => {
     document.querySelector('head meta[name="react-scroll-to-bottom:version"]').getAttribute('content')
   );
   const [disableScrollToBottomPanel, setDisableScrollToBottomPanel] = useState(false);
-  const [disableScrollToTopPanel, setDisableScrollToTopPanel] = useState(true);
+  const [disableScrollToTopPanel, setDisableScrollToTopPanel] = useState(false);
 
   const handleDisableScrollToBottomPanelClick = useCallback(
     ({ target: { checked } }) => setDisableScrollToBottomPanel(checked),

--- a/packages/playground/src/App.js
+++ b/packages/playground/src/App.js
@@ -271,6 +271,7 @@ const App = ({ nonce }) => {
           ) : (
             <ReactScrollToBottom
               className={containerClassName}
+              initialScrollBehavior="auto"
               nonce="a1b2c3d"
               scroller={limitAutoScrollHeight ? scroller : undefined}
               scrollViewClassName={scrollViewCSS + ''}
@@ -310,6 +311,7 @@ const App = ({ nonce }) => {
           ) : (
             <ReactScrollToBottom
               className={containerClassName}
+              initialScrollBehavior="auto"
               mode="top"
               nonce="a1b2c3d"
               scroller={limitAutoScrollHeight ? scroller : undefined}

--- a/packages/playground/src/CommandBar.js
+++ b/packages/playground/src/CommandBar.js
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
 import createEmotion from 'create-emotion';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import {
-  useObserveScrollPosition,
   useScrollTo,
   useScrollToBottom,
   useScrollToEnd,
@@ -37,30 +36,23 @@ const ROOT_STYLE = {
 const CommandBar = ({ nonce }) => {
   const rootCSS = useMemo(() => createEmotion({ nonce }).css(ROOT_STYLE), [nonce]);
 
-  const scrollTopRef = useRef();
-
   const scrollTo = useScrollTo();
   const scrollToBottom = useScrollToBottom();
   const scrollToEnd = useScrollToEnd();
   const scrollToStart = useScrollToStart();
   const scrollToTop = useScrollToTop();
+  const [options, setOptions] = useState({ behavior: 'smooth' });
 
-  const handleScrollTo100pxClick = useCallback(() => scrollTo(100, { behavior: 'smooth' }), [scrollTo]);
-  const handleScrollToBottomClick = useCallback(() => scrollToBottom({ behavior: 'smooth' }), [scrollToBottom]);
-  const handleScrollToEndClick = useCallback(() => scrollToEnd({ behavior: 'smooth' }), [scrollToEnd]);
-  const handleScrollToStartClick = useCallback(() => scrollToStart({ behavior: 'smooth' }), [scrollToStart]);
-  const handleScrollToTopClick = useCallback(() => scrollToTop({ behavior: 'smooth' }), [scrollToTop]);
-
-  useObserveScrollPosition(
-    ({ scrollTop }) => {
-      const { current } = scrollTopRef;
-
-      // We are directly writing to "innerText" for performance reason.
-      if (current) {
-        current.innerText = scrollTop + 'px';
-      }
+  const handleScrollTo100pxClick = useCallback(() => scrollTo(100, options), [options, scrollTo]);
+  const handleScrollToBottomClick = useCallback(() => scrollToBottom(options), [options, scrollToBottom]);
+  const handleScrollToEndClick = useCallback(() => scrollToEnd(options), [options, scrollToEnd]);
+  const handleScrollToStartClick = useCallback(() => scrollToStart(options), [options, scrollToStart]);
+  const handleScrollToTopClick = useCallback(() => scrollToTop(options), [options, scrollToTop]);
+  const handleSmoothChange = useCallback(
+    ({ target: { checked } }) => {
+      setOptions({ behavior: checked ? 'smooth' : 'auto' });
     },
-    [scrollTopRef]
+    [setOptions]
   );
 
   return (
@@ -91,7 +83,12 @@ const CommandBar = ({ nonce }) => {
             100px
           </button>
         </li>
-        <li ref={scrollTopRef}></li>
+        <li>
+          <label>
+            <input checked={options.behavior === 'smooth'} onChange={handleSmoothChange} type="checkbox" />
+            Smooth
+          </label>
+        </li>
       </ul>
     </div>
   );

--- a/packages/playground/src/CommandBar.js
+++ b/packages/playground/src/CommandBar.js
@@ -1,57 +1,35 @@
-import createEmotion from 'create-emotion';
 import classNames from 'classnames';
+import createEmotion from 'create-emotion';
 import React, { useCallback, useMemo, useRef } from 'react';
 
 import {
-  useAnimating,
-  useAtBottom,
-  useAtEnd,
-  useAtStart,
-  useAtTop,
-  useMode,
   useObserveScrollPosition,
   useScrollTo,
   useScrollToBottom,
   useScrollToEnd,
   useScrollToStart,
-  useScrollToTop,
-  useSticky
+  useScrollToTop
 } from 'react-scroll-to-bottom';
 
 const ROOT_STYLE = {
-  backgroundColor: '#FFF',
-  boxShadow: '0 0 10px rgba(0, 0, 0, .2)',
+  '&.command-bar': {
+    backgroundColor: '#FFF',
+    boxShadow: '0 0 10px rgba(0, 0, 0, .2)',
 
-  '& > ul': {
-    display: 'flex',
-    listStyleType: 'none',
-    margin: 0,
-    padding: 10,
-
-    '&:first-child': {
-      paddingBottom: 0
+    '& .command-bar__actions': {
+      display: 'flex',
+      listStyleType: 'none',
+      margin: 0,
+      padding: 10
     },
 
-    '& > li:not(:first-child)': {
-      marginLeft: 4
-    }
-  },
+    '& .command-bar__action': {
+      fontSize: 11,
+      height: 40,
 
-  '& > .badges > li': {
-    alignItems: 'center',
-    backgroundColor: '#DDD',
-    borderRadius: 5,
-    display: 'flex',
-    flex: 1,
-    fontFamily: 'Arial',
-    fontSize: '50%',
-    justifyContent: 'center',
-    padding: '2px 4px',
-    textAlign: 'center',
-
-    '&.lit': {
-      backgroundColor: 'Red',
-      color: 'White'
+      '&:not(:first-child)': {
+        marginLeft: 4
+      }
     }
   }
 };
@@ -60,13 +38,6 @@ const CommandBar = ({ nonce }) => {
   const rootCSS = useMemo(() => createEmotion({ nonce }).css(ROOT_STYLE), [nonce]);
 
   const scrollTopRef = useRef();
-  const [animating] = useAnimating();
-  const [atBottom] = useAtBottom();
-  const [atEnd] = useAtEnd();
-  const [atStart] = useAtStart();
-  const [atTop] = useAtTop();
-  const [mode] = useMode();
-  const [sticky] = useSticky();
 
   const scrollTo = useScrollTo();
   const scrollToBottom = useScrollToBottom();
@@ -93,33 +64,34 @@ const CommandBar = ({ nonce }) => {
   );
 
   return (
-    <div className={rootCSS + ''}>
-      <ul className="actions">
+    <div className={classNames(rootCSS + '', 'command-bar')}>
+      <ul className="command-bar__actions">
         <li>
-          <button onClick={handleScrollToBottomClick}>Scroll to bottom</button>
+          <button className="command-bar__action" onClick={handleScrollToBottomClick}>
+            Scroll to bottom
+          </button>
         </li>
         <li>
-          <button onClick={handleScrollToTopClick}>Scroll to top</button>
+          <button className="command-bar__action" onClick={handleScrollToTopClick}>
+            Scroll to top
+          </button>
         </li>
         <li>
-          <button onClick={handleScrollToStartClick}>Scroll to start</button>
+          <button className="command-bar__action" onClick={handleScrollToStartClick}>
+            Scroll to start
+          </button>
         </li>
         <li>
-          <button onClick={handleScrollToEndClick}>Scroll to end</button>
+          <button className="command-bar__action" onClick={handleScrollToEndClick}>
+            Scroll to end
+          </button>
         </li>
         <li>
-          <button onClick={handleScrollTo100pxClick}>100px</button>
+          <button className="command-bar__action" onClick={handleScrollTo100pxClick}>
+            100px
+          </button>
         </li>
         <li ref={scrollTopRef}></li>
-      </ul>
-      <ul className="badges">
-        <li className={classNames({ lit: animating })}>ANIMATING</li>
-        <li className={classNames({ lit: atBottom })}>AT BOTTOM</li>
-        <li className={classNames({ lit: atEnd })}>AT END</li>
-        <li className={classNames({ lit: atStart })}>AT START</li>
-        <li className={classNames({ lit: atTop })}>AT TOP</li>
-        <li className={classNames({ lit: mode !== 'top' })}>STICK TO BOTTOM</li>
-        <li className={classNames({ lit: sticky })}>STICKY</li>
       </ul>
     </div>
   );

--- a/packages/playground/src/StatusBar.js
+++ b/packages/playground/src/StatusBar.js
@@ -45,6 +45,11 @@ const ROOT_STYLE = {
       '&.status-bar__badge--lit': {
         backgroundColor: 'Red',
         color: 'White'
+      },
+
+      '&.status-bar__badge--lit-green': {
+        backgroundColor: 'Green',
+        color: 'White'
       }
     }
   }
@@ -78,16 +83,19 @@ const StatusBar = ({ className, nonce }) => {
   return (
     <div className={classNames(rootCSS + '', 'status-bar', className)}>
       <ul className="status-bar__badges">
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit-green': mode !== 'top' })}>
+          STICK TO BOTTOM
+        </li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': animating })}>ANIMATING</li>
-        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': animatingToEnd })}>ANIMATING TO END</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': animatingToEnd })}>
+          ANIMATING TO END
+        </li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atBottom })}>AT BOTTOM</li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atEnd })}>AT END</li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atStart })}>AT START</li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atTop })}>AT TOP</li>
-        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': mode !== 'top' })}>
-          STICK TO BOTTOM
-        </li>
         <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': sticky })}>STICKY</li>
+        <li className={classNames('status-bar__badge')} ref={scrollTopRef}></li>
       </ul>
     </div>
   );

--- a/packages/playground/src/StatusBar.js
+++ b/packages/playground/src/StatusBar.js
@@ -1,0 +1,96 @@
+import classNames from 'classnames';
+import createEmotion from 'create-emotion';
+import React, { useMemo, useRef } from 'react';
+
+import {
+  useAnimating,
+  useAnimatingToEnd,
+  useAtBottom,
+  useAtEnd,
+  useAtStart,
+  useAtTop,
+  useMode,
+  useObserveScrollPosition,
+  useSticky
+} from 'react-scroll-to-bottom';
+
+const ROOT_STYLE = {
+  '&.status-bar': {
+    backgroundColor: 'rgba(255, 255, 255, .5)',
+    boxShadow: '0 0 10px rgba(0, 0, 0, .2)',
+
+    '& .status-bar__badges': {
+      display: 'flex',
+      listStyleType: 'none',
+      margin: 0,
+      padding: 10
+    },
+
+    '& .status-bar__badge': {
+      alignItems: 'center',
+      backgroundColor: '#DDD',
+      borderRadius: 5,
+      display: 'flex',
+      flex: 1,
+      fontFamily: 'Arial',
+      fontSize: '50%',
+      justifyContent: 'center',
+      padding: '2px 4px',
+      textAlign: 'center',
+
+      '&:not(:first-child)': {
+        marginLeft: 4
+      },
+
+      '&.status-bar__badge--lit': {
+        backgroundColor: 'Red',
+        color: 'White'
+      }
+    }
+  }
+};
+
+const StatusBar = ({ className, nonce }) => {
+  const rootCSS = useMemo(() => createEmotion({ nonce }).css(ROOT_STYLE), [nonce]);
+
+  const scrollTopRef = useRef();
+  const [animating] = useAnimating();
+  const [animatingToEnd] = useAnimatingToEnd();
+  const [atBottom] = useAtBottom();
+  const [atEnd] = useAtEnd();
+  const [atStart] = useAtStart();
+  const [atTop] = useAtTop();
+  const [mode] = useMode();
+  const [sticky] = useSticky();
+
+  useObserveScrollPosition(
+    ({ scrollTop }) => {
+      const { current } = scrollTopRef;
+
+      // We are directly writing to "innerText" for performance reason.
+      if (current) {
+        current.innerText = scrollTop + 'px';
+      }
+    },
+    [scrollTopRef]
+  );
+
+  return (
+    <div className={classNames(rootCSS + '', 'status-bar', className)}>
+      <ul className="status-bar__badges">
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': animating })}>ANIMATING</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': animatingToEnd })}>ANIMATING TO END</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atBottom })}>AT BOTTOM</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atEnd })}>AT END</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atStart })}>AT START</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': atTop })}>AT TOP</li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': mode !== 'top' })}>
+          STICK TO BOTTOM
+        </li>
+        <li className={classNames('status-bar__badge', { 'status-bar__badge--lit': sticky })}>STICKY</li>
+      </ul>
+    </div>
+  );
+};
+
+export default StatusBar;


### PR DESCRIPTION
## Changelog

### Added

- Added `scroller` prop for limiting scroll distance when `mode` is set to `bottom`, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
- Added `initialScrollBehavior` prop for first scroll behavior. When set to `"auto"` (discrete scrolling), it will jump to end on initialization. in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
- Added `debug` prop for dumping debug log to console, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)
- Improved performance by separating `StateContext` into 2 tiers, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)

### Fixed

- Emptying container should regain stickiness, in PR [#73](https://github.com/compulim/react-scroll-to-bottom/pull/73)

## Design

### `scroller` prop

Added a `scroller` prop to programmatically control how far to scroll, when the view is sticky.

If the scroll distance is less than maximum, auto-scroll will pause.

### `initialScrollBehavior` prop

Added an `initialScrollBehavior` prop to control the first auto-scroll behavior. If set to `"auto"`, the scroll will be discrete (a.k.a. jump).