### PR TITLE
Log will be disabled if debug set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed [#75](https://github.com/compulim/react-scroll-to-bottom/issues/75). If `debug` is set, it will show debug in console log. If not specified, it will fallback to `NODE_ENV === 'production'`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX).
+- Fixed [#75](https://github.com/compulim/react-scroll-to-bottom/issues/75). If `debug` is set, it will show debug in console log. If not specified, it will fallback to `NODE_ENV === 'production'`, in PR [#77](https://github.com/compulim/react-scroll-to-bottom/pull/77).
 
 ## [4.1.0] - 2021-01-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed [#75](https://github.com/compulim/react-scroll-to-bottom/issues/75). If `debug` is set, it will show debug in console log. If not specified, it will fallback to `NODE_ENV === 'production'`, in PR [#XXX](https://github.com/compulim/react-scroll-to-bottom/pull/XXX).
+
 ## [4.1.0] - 2021-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ export default props => (
 
 ## Props
 
-| Name                    | Type       | Default          | Description                                                                                                                    |
-| ----------------------- | ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `checkInterval`         | `number`   | 150              | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)                                                     |
-| `className`             | `string`   |                  | Set the class name for the root element                                                                                        |
-| `debounce`              | `number`   | `17`             | Set the debounce for tracking the `onScroll` event                                                                             |
-| `debug`                 | `bool`     | false            | Show debug information in console                                                                                              |
-| `followButtonClassName` | `string`   |                  | Set the class name for the follow button                                                                                       |
-| `initialScrollBehavior` | `string`   | `smooth`         | Set the initial scroll behavior, either `"auto"` (discrete scrolling) or `"smooth"`                                            |
-| `mode`                  | `string`   | `"bottom"`       | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top                                                           |
-| `nonce`                 | `string`   |                  | Set the nonce for [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) |
-| `scroller`              | `function` | `() => Infinity` | A function to determine how far should scroll when scroll is needed                                                            |
-| `scrollViewClassName`   | `string`   |                  | Set the class name for the container element that house all `props.children`                                                   |
+| Name                    | Type       | Default                      | Description                                                                                                                    |
+| ----------------------- | ---------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `checkInterval`         | `number`   | 150                          | Recurring interval of stickiness check, in milliseconds (minimum is 17 ms)                                                     |
+| `className`             | `string`   |                              | Set the class name for the root element                                                                                        |
+| `debounce`              | `number`   | `17`                         | Set the debounce for tracking the `onScroll` event                                                                             |
+| `debug`                 | `bool`     | `NODE_ENV === 'development'` | Show debug information in console                                                                                              |
+| `followButtonClassName` | `string`   |                              | Set the class name for the follow button                                                                                       |
+| `initialScrollBehavior` | `string`   | `smooth`                     | Set the initial scroll behavior, either `"auto"` (discrete scrolling) or `"smooth"`                                            |
+| `mode`                  | `string`   | `"bottom"`                   | Set it to `"bottom"` for scroll-to-bottom, `"top"` for scroll-to-top                                                           |
+| `nonce`                 | `string`   |                              | Set the nonce for [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) |
+| `scroller`              | `function` | `() => Infinity`             | A function to determine how far should scroll when scroll is needed                                                            |
+| `scrollViewClassName`   | `string`   |                              | Set the class name for the container element that house all `props.children`                                                   |
 
 ## Hooks
 

--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -75,7 +75,7 @@ BasicScrollToBottom.defaultProps = {
   children: undefined,
   className: undefined,
   debounce: undefined,
-  debug: false,
+  debug: undefined,
   followButtonClassName: undefined,
   initialScrollBehavior: 'smooth',
   mode: undefined,

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -53,13 +53,13 @@ const Composer = ({
   checkInterval,
   children,
   debounce,
-  debug: forceDebug,
+  debug: debugFromProp,
   initialScrollBehavior,
   mode,
   nonce,
   scroller
 }) => {
-  const debug = useMemo(() => createDebug(`<ScrollToBottom>`, { force: forceDebug }), [forceDebug]);
+  const debug = useMemo(() => createDebug(`<ScrollToBottom>`, { force: debugFromProp }), [debugFromProp]);
 
   mode = mode === MODE_TOP ? MODE_TOP : MODE_BOTTOM;
 
@@ -580,7 +580,7 @@ Composer.defaultProps = {
   checkInterval: 100,
   children: undefined,
   debounce: 17,
-  debug: false,
+  debug: undefined,
   initialScrollBehavior: 'smooth',
   mode: undefined,
   nonce: undefined,

--- a/packages/component/src/utils/debug.js
+++ b/packages/component/src/utils/debug.js
@@ -9,8 +9,8 @@ function format(category, arg0, ...args) {
   return [`%c${category}%c ${arg0}`, ...styleConsole('green', 'white'), ...args];
 }
 
-export default function debug(category, { force = false } = {}) {
-  if (!force && NODE_ENV !== 'development') {
+export default function debug(category, { force = NODE_ENV === 'development' } = {}) {
+  if (!force) {
     return () => 0;
   }
 


### PR DESCRIPTION
## Changelog

### Fixed

- Fixed [#75](https://github.com/compulim/react-scroll-to-bottom/issues/75). If `debug` is set, it will show debug in console log. If not specified, it will fallback to `NODE_ENV === 'production'`, in PR [#77](https://github.com/compulim/react-scroll-to-bottom/pull/77).
