### PR TITLE
Add tests

### DIFF
--- a/__tests__/assets/index.css
+++ b/__tests__/assets/index.css
@@ -1,5 +1,6 @@
 body,
-html {
+html,
+#app {
   height: 100%;
 }
 
@@ -11,9 +12,16 @@ body {
   margin: 0;
 }
 
+#app {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
 .react-scroll-to-bottom {
   background: White;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-  height: 640px;
+  height: 100%;
+  max-height: 640px;
   width: 360px;
 }

--- a/__tests__/race-condition-append-while-scrolling.html
+++ b/__tests__/race-condition-append-while-scrolling.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="/react-scroll-to-bottom.development.js"></script>
+    <script src="/test-harness.js"></script>
+    <script src="/assets/page-object-model.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script type="text/babel" data-presets="react">
+    'use strict';
+
+    const RunFunction = ({ fn }) => {
+      fn && fn();
+
+      return false;
+    };
+
+    async function render(paragraphs, fn) {
+      let called;
+      const once =
+        fn &&
+        (() => {
+          !called && fn();
+          called = 1;
+        });
+
+      await new Promise(resolve =>
+        ReactDOM.render(
+          <div className="react-scroll-to-bottom">
+            {/* Set checkInterval to 1 to increase the probability of race condition. */}
+            <ReactScrollToBottom.Composer checkInterval={1}>
+              <ReactScrollToBottom.Panel className="scrollable">
+                {paragraphs.map((paragraph, index) => (
+                  <div key={index}>
+                    {index + 1}: {paragraph}
+                  </div>
+                ))}
+              </ReactScrollToBottom.Panel>
+              <RunFunction fn={once} />
+            </ReactScrollToBottom.Composer>
+          </div>,
+          document.getElementById('app'),
+          resolve
+        )
+      );
+    }
+
+    run(async function () {
+      let paragraphs = pageObjects.paragraphs;
+
+      for (let i = 0; i < 20; i++) {
+        // Preparation: scrollable should stay at the bottom before start.
+        await render(paragraphs, () => ReactScrollToBottom.useScrollTo()('100%', { behavior: 'auto' }));
+        await pageObjects.scrollStabilizedAtBottom();
+
+        const scrollable = document.getElementsByClassName('scrollable')[0];
+
+        // Call scrollTo() and wait until the first "scroll" event.
+        const scrolling = new Promise(resolve => scrollable.addEventListener('scroll', resolve, { once: true }));
+
+        // Alternate between discrete and smooth scrolling.
+        scrollable.scrollTo({ behavior: i % 2 ? 'auto' : 'smooth', top: 0 });
+
+        // "scroll" event dispatched after we call scrollTo(), it should be safe to append a new element.
+        // Withou the "scroll" event, the component can't guarantee if it is safe to append, due to technical difficulties.
+        await scrolling;
+
+        // Add a new paragraph.
+        paragraphs = [...paragraphs, pageObjects.paragraphs[~~(Math.random() * pageObjects.paragraphs.length)]];
+
+        await render(paragraphs);
+
+        // After a new paragraph is added, it should continue to scroll to the top.
+        await pageObjects.scrollStabilizedAtTop();
+      }
+    });
+  </script>
+</html>

--- a/__tests__/race-condition-append-while-scrolling.js
+++ b/__tests__/race-condition-append-while-scrolling.js
@@ -1,0 +1,9 @@
+/** @jest-environment ./packages/test-harness/JestEnvironment */
+
+// Tests for race condition will take longer time to run.
+jest.setTimeout(30000);
+
+describe('when under heavy load', () => {
+  test('append an element while scrolling to the top should continue to scroll', () =>
+    runHTML('race-condition-scroll-into-view'));
+});

--- a/__tests__/race-condition-scroll-into-view.html
+++ b/__tests__/race-condition-scroll-into-view.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="/react-scroll-to-bottom.development.js"></script>
+    <script src="/test-harness.js"></script>
+    <script src="/assets/page-object-model.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script type="text/babel" data-presets="react">
+    'use strict';
+
+    const Panel = () => {
+      const [sticky] = ReactScrollToBottom.useSticky();
+
+      return (
+        <ReactScrollToBottom.Panel className={`scrollable ${sticky ? 'sticky' : ''}`}>
+          {pageObjects.paragraphs.map(paragraph => (
+            <div key={paragraph}>
+              <div>{paragraph}</div>
+              {/* Adds an element with complex layout to slow down rendering. */}
+              {new Array(1000).fill().map((_, index) => (
+                <div key={index} />
+              ))}
+            </div>
+          ))}
+        </ReactScrollToBottom.Panel>
+      );
+    };
+
+    const RunFunction = ({ fn }) => {
+      fn && fn();
+
+      return false;
+    };
+
+    async function render(fn) {
+      let called;
+      const once =
+        fn &&
+        (() => {
+          !called && fn();
+          called = 1;
+        });
+
+      await new Promise(resolve =>
+        ReactDOM.render(
+          <div className="react-scroll-to-bottom">
+            {/* Set checkInterval to 1 to increase the probability of race condition. */}
+            <ReactScrollToBottom.Composer checkInterval={1}>
+              <Panel />
+              <RunFunction fn={once} />
+            </ReactScrollToBottom.Composer>
+          </div>,
+          document.getElementById('app'),
+          resolve
+        )
+      );
+    }
+
+    run(async function () {
+      await render();
+
+      for (let i = 0; i < 20; i++) {
+        await pageObjects.scrollStabilizedAtBottom();
+        await became('sticky', () => document.getElementsByClassName('sticky').length, 5000);
+
+        if (i % 2) {
+          document.getElementsByClassName('scrollable')[0].scrollTo({ behavior: 'auto', top: 0 });
+        } else {
+          document.getElementsByClassName('scrollable')[0].children[0].scrollIntoView({ behavior: 'auto' });
+        }
+
+        // The race condition occurs in this place:
+        // - When under load
+        // - Call `scrollTo` or `scrollIntoView` with `behavior` set to `auto`, it will scroll up
+        // - The race condition will cause it to scroll back down immediately
+
+        await pageObjects.scrollStabilizedAtTop();
+        await became('not sticky', () => !document.getElementsByClassName('sticky').length, 5000);
+
+        await render(() => ReactScrollToBottom.useScrollTo()('100%', { behavior: 'smooth' }));
+      }
+    });
+  </script>
+</html>

--- a/__tests__/race-condition-scroll-into-view.js
+++ b/__tests__/race-condition-scroll-into-view.js
@@ -1,0 +1,8 @@
+/** @jest-environment ./packages/test-harness/JestEnvironment */
+
+// Tests for race condition will take longer time to run.
+jest.setTimeout(30000);
+
+describe('when under heavy load', () => {
+  test('calling scrollIntoView should scroll properly', () => runHTML('race-condition-scroll-into-view'));
+});

--- a/__tests__/resize.html
+++ b/__tests__/resize.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+    <link href="/assets/index.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="/react-scroll-to-bottom.development.js"></script>
+    <script src="/test-harness.js"></script>
+    <script src="/assets/page-object-model.js"></script>
+    <style type="text/css">
+      .react-scroll-to-bottom.small {
+        height: 320px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script type="text/babel" data-presets="react">
+    'use strict';
+
+    function appendParagraph(paragraphs) {
+      return [...paragraphs, pageObjects.paragraphs[~~(Math.random() * pageObjects.paragraphs.length)]];
+    }
+
+    async function render(paragraphs, className) {
+      await new Promise(resolve =>
+        ReactDOM.render(
+          <ReactScrollToBottom.default
+            className={`react-scroll-to-bottom ${className || ''}`}
+            followButtonClassName="follow"
+            scrollViewClassName="scrollable"
+          >
+            {paragraphs.map((paragraph, index) => (
+              <p key={index}>
+                {index}: {paragraph}
+              </p>
+            ))}
+          </ReactScrollToBottom.default>,
+          document.getElementById('app'),
+          resolve
+        )
+      );
+    }
+
+    // This is testing of 4-1-5-1-1 on the test page. It should not lose stickiness.
+    run(async function () {
+      let paragraphs = pageObjects.paragraphs;
+
+      await render(paragraphs);
+
+      await render(paragraphs, 'small');
+      await pageObjects.scrollStabilizedAtBottom();
+
+      paragraphs = appendParagraph(paragraphs);
+      await render(paragraphs, 'small');
+      await pageObjects.scrollStabilizedAtBottom();
+
+      await render(paragraphs);
+      await pageObjects.scrollStabilizedAtBottom();
+
+      paragraphs = appendParagraph(paragraphs);
+      await render(paragraphs);
+      await pageObjects.scrollStabilizedAtBottom();
+
+      paragraphs = appendParagraph(paragraphs);
+      await render(paragraphs);
+      await pageObjects.scrollStabilizedAtBottom();
+    });
+  </script>
+</html>

--- a/__tests__/resize.js
+++ b/__tests__/resize.js
@@ -1,0 +1,3 @@
+/** @jest-environment ./packages/test-harness/JestEnvironment */
+
+test('resizing should not lose stickiness', () => runHTML('resize'));

--- a/packages/test-harness/src/browser/assertions/became.js
+++ b/packages/test-harness/src/browser/assertions/became.js
@@ -1,7 +1,3 @@
-import sleep from '../../common/utils/sleep';
-
-const CHECK_INTERVAL = 100;
-
 export default async function became(message, fn, timeout) {
   if (typeof timeout !== 'number') {
     throw new Error('"timeout" argument must be set.');
@@ -12,7 +8,7 @@ export default async function became(message, fn, timeout) {
       return;
     }
 
-    await sleep(CHECK_INTERVAL);
+    await new Promise(requestAnimationFrame);
   }
 
   throw new Error(`Timed out while waiting for page condition "${message}" after ${timeout / 1000} seconds.`);

--- a/packages/test-harness/src/browser/assertions/stabilized.js
+++ b/packages/test-harness/src/browser/assertions/stabilized.js
@@ -1,8 +1,4 @@
 import became from './became';
-import sleep from '../../common/utils/sleep';
-
-// 17 ms is a frame on a display with 60 Hz refresh rate.
-const WAIT_INTERVAL = 17;
 
 export default function stabilized(name, getValue, count, timeout) {
   const values = [];
@@ -26,7 +22,7 @@ export default function stabilized(name, getValue, count, timeout) {
       }
 
       // If not, sleep for a frame and check again.
-      await sleep(WAIT_INTERVAL);
+      await new Promise(requestAnimationFrame);
 
       return false;
     },


### PR DESCRIPTION
Add a few tests:

- Race conditions
   - Appending elements while scrolling to top
   - Calling `HTMLElement.scrollTo()` or `HTMLElement.scrollIntoView()` to scroll to the top should unstick properly
- Resizing scroll view should not lose stickiness