### PR TITLE
Remove defaultProps (use default parameters)

### DIFF
--- a/packages/component/src/BasicScrollToBottom.js
+++ b/packages/component/src/BasicScrollToBottom.js
@@ -22,13 +22,6 @@ const BasicScrollToBottomCore = ({ children, className, followButtonClassName, s
   );
 };
 
-BasicScrollToBottomCore.defaultProps = {
-  children: undefined,
-  className: undefined,
-  followButtonClassName: undefined,
-  scrollViewClassName: undefined
-};
-
 BasicScrollToBottomCore.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
@@ -43,7 +36,7 @@ const BasicScrollToBottom = ({
   debounce,
   debug,
   followButtonClassName,
-  initialScrollBehavior,
+  initialScrollBehavior = 'smooth',
   mode,
   nonce,
   scroller,
@@ -69,21 +62,6 @@ const BasicScrollToBottom = ({
     </BasicScrollToBottomCore>
   </Composer>
 );
-
-BasicScrollToBottom.defaultProps = {
-  checkInterval: undefined,
-  children: undefined,
-  className: undefined,
-  debounce: undefined,
-  debug: undefined,
-  followButtonClassName: undefined,
-  initialScrollBehavior: 'smooth',
-  mode: undefined,
-  nonce: undefined,
-  scroller: undefined,
-  scrollViewClassName: undefined,
-  styleOptions: undefined
-};
 
 BasicScrollToBottom.propTypes = {
   checkInterval: PropTypes.number,

--- a/packages/component/src/EventSpy.js
+++ b/packages/component/src/EventSpy.js
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 
 import debounceFn from './debounce';
 
-const EventSpy = ({ debounce, name, onEvent, target }) => {
+const EventSpy = ({ debounce = 200, name, onEvent, target }) => {
   // We need to save the "onEvent" to ref.
   // This is because "onEvent" may change from time to time, but debounce may still fire to the older callback.
   const onEventRef = useRef();
@@ -36,10 +36,6 @@ const EventSpy = ({ debounce, name, onEvent, target }) => {
   }, [name, handleEvent, target]);
 
   return false;
-};
-
-EventSpy.defaultProps = {
-  debounce: 200
 };
 
 export default EventSpy;

--- a/packages/component/src/ScrollToBottom/AutoHideFollowButton.js
+++ b/packages/component/src/ScrollToBottom/AutoHideFollowButton.js
@@ -27,7 +27,7 @@ const ROOT_STYLE = {
   }
 };
 
-const AutoHideFollowButton = ({ children, className }) => {
+const AutoHideFollowButton = ({ children, className = '' }) => {
   const [sticky] = useSticky();
   const rootCSS = useStyleToClassName()(ROOT_STYLE);
   const scrollToEnd = useScrollToEnd();
@@ -39,11 +39,6 @@ const AutoHideFollowButton = ({ children, className }) => {
       </button>
     )
   );
-};
-
-AutoHideFollowButton.defaultProps = {
-  children: undefined,
-  className: ''
 };
 
 AutoHideFollowButton.propTypes = {

--- a/packages/component/src/ScrollToBottom/Composer.js
+++ b/packages/component/src/ScrollToBottom/Composer.js
@@ -46,14 +46,14 @@ function isEnd(animateTo, mode) {
 }
 
 const Composer = ({
-  checkInterval,
+  checkInterval = 100,
   children,
-  debounce,
+  debounce = 17,
   debug: debugFromProp,
-  initialScrollBehavior,
+  initialScrollBehavior = 'smooth',
   mode,
   nonce,
-  scroller,
+  scroller = DEFAULT_SCROLLER,
   styleOptions
 }) => {
   const debug = useMemo(() => createDebug(`<ScrollToBottom>`, { force: debugFromProp }), [debugFromProp]);
@@ -607,18 +607,6 @@ const Composer = ({
       </FunctionContext.Provider>
     </InternalContext.Provider>
   );
-};
-
-Composer.defaultProps = {
-  checkInterval: 100,
-  children: undefined,
-  debounce: 17,
-  debug: undefined,
-  initialScrollBehavior: 'smooth',
-  mode: undefined,
-  nonce: undefined,
-  scroller: DEFAULT_SCROLLER,
-  styleOptions: undefined
 };
 
 Composer.propTypes = {

--- a/packages/component/src/ScrollToBottom/Panel.js
+++ b/packages/component/src/ScrollToBottom/Panel.js
@@ -22,11 +22,6 @@ const Panel = ({ children, className }) => {
   );
 };
 
-Panel.defaultProps = {
-  children: undefined,
-  className: undefined
-};
-
 Panel.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string


### PR DESCRIPTION
This fixes React warnings: "Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead."

## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

## Specific changes

> Please list each individual specific change in this pull request.

- 